### PR TITLE
feat: add pluggable ZK/TEE attestation hook extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ cd erc721-ai
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started. Issues tagged `good-first-issue` are great entry points.
 
+## Attestation Hook (ZK / TEE)
+
+This repo includes a pluggable contract-level attestation hook for verifiable training claims:
+
+- `contracts/interfaces/ITrainingAttestationVerifier.sol`
+- `contracts/mocks/MockTrainingAttestationVerifier.sol`
+- `contracts/ERC721AIAttestationHook.sol`
+
+Design and integration details are documented in `docs/attestation-hook.md`.
+
 ## Links
 
 - **Docs:** https://docs.kcolbchain.com/erc721-ai/

--- a/contracts/ERC721AIAttestationHook.sol
+++ b/contracts/ERC721AIAttestationHook.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ITrainingAttestationVerifier} from "./interfaces/ITrainingAttestationVerifier.sol";
+
+contract ERC721AIAttestationHook {
+    struct TrainingAttestation {
+        bytes32 modelId;
+        bytes32 artifactHash;
+        bytes32 attestationHash;
+        bytes32 attestationKind;
+        address verifier;
+        uint64 verifiedAt;
+    }
+
+    address public owner;
+
+    mapping(bytes32 => address) public attestationVerifiers;
+    mapping(uint256 => TrainingAttestation) public attestationsByTokenId;
+
+    event AttestationVerifierConfigured(bytes32 indexed attestationKind, address indexed verifier);
+    event TrainingAttestationVerified(
+        uint256 indexed tokenId,
+        bytes32 indexed modelId,
+        bytes32 indexed artifactHash,
+        bytes32 attestationKind,
+        address verifier,
+        bytes32 attestationHash
+    );
+
+    error NotOwner();
+    error ZeroAddressVerifier();
+    error MissingVerifier(bytes32 attestationKind);
+    error AttestationVerificationFailed();
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) {
+            revert NotOwner();
+        }
+        _;
+    }
+
+    constructor(address initialOwner) {
+        owner = initialOwner;
+    }
+
+    function setAttestationVerifier(bytes32 attestationKind, address verifier) external onlyOwner {
+        if (verifier == address(0)) {
+            revert ZeroAddressVerifier();
+        }
+
+        attestationVerifiers[attestationKind] = verifier;
+        emit AttestationVerifierConfigured(attestationKind, verifier);
+    }
+
+    function registerAndVerifyAttestation(
+        uint256 tokenId,
+        bytes32 modelId,
+        bytes32 artifactHash,
+        bytes32 attestationKind,
+        bytes calldata attestationData
+    ) external {
+        address verifier = attestationVerifiers[attestationKind];
+        if (verifier == address(0)) {
+            revert MissingVerifier(attestationKind);
+        }
+
+        bool verified = ITrainingAttestationVerifier(verifier).verifyAttestation(
+            modelId,
+            artifactHash,
+            attestationData
+        );
+        if (!verified) {
+            revert AttestationVerificationFailed();
+        }
+
+        bytes32 attestationHash = keccak256(attestationData);
+        attestationsByTokenId[tokenId] = TrainingAttestation({
+            modelId: modelId,
+            artifactHash: artifactHash,
+            attestationHash: attestationHash,
+            attestationKind: attestationKind,
+            verifier: verifier,
+            verifiedAt: uint64(block.timestamp)
+        });
+
+        emit TrainingAttestationVerified(
+            tokenId,
+            modelId,
+            artifactHash,
+            attestationKind,
+            verifier,
+            attestationHash
+        );
+    }
+}

--- a/contracts/interfaces/ITrainingAttestationVerifier.sol
+++ b/contracts/interfaces/ITrainingAttestationVerifier.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface ITrainingAttestationVerifier {
+    function verifyAttestation(
+        bytes32 modelId,
+        bytes32 artifactHash,
+        bytes calldata attestationData
+    ) external view returns (bool);
+}

--- a/contracts/mocks/MockTrainingAttestationVerifier.sol
+++ b/contracts/mocks/MockTrainingAttestationVerifier.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ITrainingAttestationVerifier} from "../interfaces/ITrainingAttestationVerifier.sol";
+
+contract MockTrainingAttestationVerifier is ITrainingAttestationVerifier {
+    mapping(bytes32 => bool) public approvedDigests;
+    bool public acceptAll;
+
+    event AttestationDigestApprovalUpdated(bytes32 indexed digest, bool approved);
+    event AcceptAllUpdated(bool acceptAll);
+
+    function setApproval(
+        bytes32 modelId,
+        bytes32 artifactHash,
+        bytes calldata attestationData,
+        bool approved
+    ) external {
+        bytes32 digest = keccak256(abi.encode(modelId, artifactHash, attestationData));
+        approvedDigests[digest] = approved;
+        emit AttestationDigestApprovalUpdated(digest, approved);
+    }
+
+    function setAcceptAll(bool value) external {
+        acceptAll = value;
+        emit AcceptAllUpdated(value);
+    }
+
+    function verifyAttestation(
+        bytes32 modelId,
+        bytes32 artifactHash,
+        bytes calldata attestationData
+    ) external view override returns (bool) {
+        if (acceptAll) {
+            return true;
+        }
+
+        bytes32 digest = keccak256(abi.encode(modelId, artifactHash, attestationData));
+        return approvedDigests[digest];
+    }
+}

--- a/docs/attestation-hook.md
+++ b/docs/attestation-hook.md
@@ -1,0 +1,62 @@
+# Attestation Hook Extension
+
+This repository now includes a pluggable attestation hook to support verifiable training claims.
+
+## What was added
+
+- `contracts/interfaces/ITrainingAttestationVerifier.sol`
+  - Interface for verifier contracts.
+- `contracts/mocks/MockTrainingAttestationVerifier.sol`
+  - Mock verifier for local/dev usage.
+- `contracts/ERC721AIAttestationHook.sol`
+  - Registry-style hook that stores verified attestation metadata per token.
+
+## Data model
+
+Per token, the hook stores:
+
+- `modelId`: canonical model identifier hash
+- `artifactHash`: hash of training artifact / weight bundle
+- `attestationHash`: `keccak256(attestationData)`
+- `attestationKind`: kind discriminator (`bytes32`) such as `"ZK_PROOF"` or `"TEE_SIG"`
+- `verifier`: verifier contract used
+- `verifiedAt`: verification timestamp
+
+## How to plug in a production verifier
+
+1. Implement `ITrainingAttestationVerifier` for your attestation type.
+2. Deploy the verifier contract.
+3. Configure the verifier on the hook:
+
+```solidity
+hook.setAttestationVerifier(keccak256("ZK_PROOF"), verifierAddress);
+```
+
+4. Call `registerAndVerifyAttestation(...)` after mint or during metadata finalization.
+
+## Verifier interface contract
+
+```solidity
+function verifyAttestation(
+    bytes32 modelId,
+    bytes32 artifactHash,
+    bytes calldata attestationData
+) external view returns (bool);
+```
+
+### Example verifier behaviors
+
+- **ZK verifier**: decode proof bytes and verify against public inputs `(modelId, artifactHash)`.
+- **TEE verifier**: verify enclave signature over `(modelId, artifactHash, nonce)` and signer trust root.
+
+## Mock verifier usage
+
+`MockTrainingAttestationVerifier` supports two modes:
+
+- `setAcceptAll(true)` for permissive local testing.
+- `setApproval(modelId, artifactHash, attestationData, true)` for digest-specific validation.
+
+## Notes
+
+- The hook is intentionally standalone so existing ERC-721 implementations can compose it without inheritance constraints.
+- `attestationKind` is `bytes32` to keep on-chain storage cheap and avoid string comparisons.


### PR DESCRIPTION
## Summary
Implements issue #6 by adding a pluggable attestation hook module for verifiable training claims.

Closes #6
/claim #6

## What was added
- `contracts/interfaces/ITrainingAttestationVerifier.sol`
  - verifier interface for ZK/TEE style attestations
- `contracts/mocks/MockTrainingAttestationVerifier.sol`
  - mock verifier for local and CI development
- `contracts/ERC721AIAttestationHook.sol`
  - standalone hook/registry that:
    - maps attestation kinds to verifier contracts
    - verifies attestation bytes against `(modelId, artifactHash)`
    - stores verified attestation metadata per token
- `docs/attestation-hook.md`
  - integration guide explaining how to plug in production ZK/TEE verifiers
- README update linking the new attestation extension

## Testing
Attempted to compile contracts with:
- `npx --yes solc@0.8.24 --bin contracts/ERC721AIAttestationHook.sol contracts/mocks/MockTrainingAttestationVerifier.sol contracts/interfaces/ITrainingAttestationVerifier.sol`

Compilation is blocked in this environment due to a broken Node runtime dynamic library dependency (`libsimdjson.31.dylib` missing). The contract changes are self-contained and ready for CI validation.