### PR TITLE
test: add comprehensive Foundry test suite for ERC721AIAttestationHook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+cache/
+out/
+broadcast/

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,10 @@
+[profile.default]
+src = "contracts"
+out = "out"
+test = "test"
+libs = ["lib"]
+solc_version = "0.8.24"
+optimizer = true
+optimizer_runs = 200
+
+# Install OpenZeppelin for ReentrancyGuard

--- a/test/ERC721AIAttestationHook.t.sol
+++ b/test/ERC721AIAttestationHook.t.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/ERC721AIAttestationHook.sol";
+import "../contracts/mocks/MockTrainingAttestationVerifier.sol";
+
+contract ERC721AIAttestationHookTest is Test {
+    ERC721AIAttestationHook public hook;
+    MockTrainingAttestationVerifier public mockVerifier;
+    address public owner;
+    address public other;
+    bytes32 constant ATTESTATION_KIND = keccak256("zk-tee");
+
+    function setUp() public {
+        owner = address(this);
+        other = makeAddr("other");
+
+        mockVerifier = new MockTrainingAttestationVerifier();
+        hook = new ERC721AIAttestationHook(owner);
+    }
+
+    // ── Deployment ──────────────────────────────────────────────────────
+
+    function test_SetOwnerOnDeploy() public view {
+        assertEq(hook.owner(), owner);
+    }
+
+    // ── setAttestationVerifier ─────────────────────────────────────────
+
+    function test_ConfiguresVerifier() public {
+        hook.setAttestationVerifier(ATTESTATION_KIND, address(mockVerifier));
+        assertEq(hook.attestationVerifiers(ATTESTATION_KIND), address(mockVerifier));
+    }
+
+    function test_EmitsVerifierConfigured() public {
+        vm.expectEmit(true, true, false, false);
+        emit ERC721AIAttestationHook.AttestationVerifierConfigured(ATTESTATION_KIND, address(mockVerifier));
+        hook.setAttestationVerifier(ATTESTATION_KIND, address(mockVerifier));
+    }
+
+    function test_RevertWhenNonOwnerSetsVerifier() public {
+        vm.prank(other);
+        vm.expectRevert(ERC721AIAttestationHook.NotOwner.selector);
+        hook.setAttestationVerifier(ATTESTATION_KIND, address(mockVerifier));
+    }
+
+    function test_RevertWhenZeroAddressVerifier() public {
+        vm.expectRevert(ERC721AIAttestationHook.ZeroAddressVerifier.selector);
+        hook.setAttestationVerifier(ATTESTATION_KIND, address(0));
+    }
+
+    function test_CanUpdateExistingVerifier() public {
+        hook.setAttestationVerifier(ATTESTATION_KIND, address(mockVerifier));
+        hook.setAttestationVerifier(ATTESTATION_KIND, other);
+        assertEq(hook.attestationVerifiers(ATTESTATION_KIND), other);
+    }
+
+    // ── registerAndVerifyAttestation ────────────────────────────────────
+
+    function test_RegistersVerifiedAttestation() public {
+        hook.setAttestationVerifier(ATTESTATION_KIND, address(mockVerifier));
+
+        bytes32 modelId = keccak256("model-1");
+        bytes32 artifactHash = keccak256("artifact-1");
+        bytes memory attestationData = "test-attestation";
+
+        mockVerifier.setApproval(modelId, artifactHash, attestationData, true);
+
+        hook.registerAndVerifyAttestation(1, modelId, artifactHash, ATTESTATION_KIND, attestationData);
+
+        (
+            bytes32 storedModelId,
+            bytes32 storedArtifactHash,
+            bytes32 storedAttestationHash,
+            bytes32 storedAttestationKind,
+            address storedVerifier,
+            uint64 storedVerifiedAt
+        ) = hook.attestationsByTokenId(1);
+
+        assertEq(storedModelId, modelId);
+        assertEq(storedArtifactHash, artifactHash);
+        assertEq(storedAttestationKind, ATTESTATION_KIND);
+        assertEq(storedVerifier, address(mockVerifier));
+        assertGt(storedVerifiedAt, 0);
+        assertEq(storedAttestationHash, keccak256(attestationData));
+    }
+
+    function test_RevertWhenVerifierNotConfigured() public {
+        bytes32 unknownKind = keccak256("unknown");
+        vm.expectRevert(abi.encodeWithSelector(ERC721AIAttestationHook.MissingVerifier.selector, unknownKind));
+        hook.registerAndVerifyAttestation(1, keccak256("m"), keccak256("a"), unknownKind, "data");
+    }
+
+    function test_RevertWhenVerificationFails() public {
+        hook.setAttestationVerifier(ATTESTATION_KIND, address(mockVerifier));
+        vm.expectRevert(ERC721AIAttestationHook.AttestationVerificationFailed.selector);
+        hook.registerAndVerifyAttestation(1, keccak256("m"), keccak256("a"), ATTESTATION_KIND, "bad");
+    }
+
+    function test_WorksWithAcceptAllMode() public {
+        hook.setAttestationVerifier(ATTESTATION_KIND, address(mockVerifier));
+        mockVerifier.setAcceptAll(true);
+
+        hook.registerAndVerifyAttestation(1, keccak256("m"), keccak256("a"), ATTESTATION_KIND, "any");
+    }
+
+    function test_EmitsAttestationVerified() public {
+        hook.setAttestationVerifier(ATTESTATION_KIND, address(mockVerifier));
+        mockVerifier.setAcceptAll(true);
+
+        bytes32 modelId = keccak256("m");
+        bytes32 artifactHash = keccak256("a");
+        bytes memory attestationData = "data";
+        bytes32 attHash = keccak256(attestationData);
+
+        vm.expectEmit(true, true, true, false);
+        emit ERC721AIAttestationHook.TrainingAttestationVerified(1, modelId, artifactHash, ATTESTATION_KIND, address(mockVerifier), attHash);
+        hook.registerAndVerifyAttestation(1, modelId, artifactHash, ATTESTATION_KIND, attestationData);
+    }
+
+    function test_CanOverwriteAttestation() public {
+        hook.setAttestationVerifier(ATTESTATION_KIND, address(mockVerifier));
+        mockVerifier.setAcceptAll(true);
+
+        hook.registerAndVerifyAttestation(1, keccak256("m"), keccak256("a"), ATTESTATION_KIND, "first");
+        hook.registerAndVerifyAttestation(1, keccak256("m"), keccak256("a"), ATTESTATION_KIND, "second");
+
+        (,,, , , uint64 verifiedAt) = hook.attestationsByTokenId(1);
+        assertGt(verifiedAt, 0);
+    }
+
+    function test_AnyoneCanRegisterIfVerifierSet() public {
+        hook.setAttestationVerifier(ATTESTATION_KIND, address(mockVerifier));
+        mockVerifier.setAcceptAll(true);
+
+        vm.prank(other);
+        hook.registerAndVerifyAttestation(1, keccak256("m"), keccak256("a"), ATTESTATION_KIND, "data");
+    }
+
+    function test_MultipleTokenAttestations() public {
+        hook.setAttestationVerifier(ATTESTATION_KIND, address(mockVerifier));
+        mockVerifier.setAcceptAll(true);
+
+        hook.registerAndVerifyAttestation(1, keccak256("m1"), keccak256("a1"), ATTESTATION_KIND, "d1");
+        hook.registerAndVerifyAttestation(2, keccak256("m2"), keccak256("a2"), ATTESTATION_KIND, "d2");
+
+        (bytes32 m1,,,,,) = hook.attestationsByTokenId(1);
+        (bytes32 m2,,,,,) = hook.attestationsByTokenId(2);
+        assertEq(m1, keccak256("m1"));
+        assertEq(m2, keccak256("m2"));
+    }
+
+    function test_MultipleAttestationKinds() public {
+        bytes32 kind1 = keccak256("zk-tee");
+        bytes32 kind2 = keccak256("sgx");
+
+        MockTrainingAttestationVerifier verifier2 = new MockTrainingAttestationVerifier();
+        verifier2.setAcceptAll(true);
+
+        hook.setAttestationVerifier(kind1, address(mockVerifier));
+        hook.setAttestationVerifier(kind2, address(verifier2));
+
+        mockVerifier.setAcceptAll(true);
+
+        hook.registerAndVerifyAttestation(1, keccak256("m"), keccak256("a"), kind1, "d1");
+        hook.registerAndVerifyAttestation(2, keccak256("m"), keccak256("a"), kind2, "d2");
+    }
+}

--- a/test/ERC721AIAttestationHook.test.js
+++ b/test/ERC721AIAttestationHook.test.js
@@ -1,0 +1,114 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("ERC721AIAttestationHook", function () {
+  let hook, mockVerifier;
+  let owner, other, verifierAddr;
+
+  const ATTESTATION_KIND = ethers.encodeBytes32String("zk-tee");
+
+  beforeEach(async function () {
+    [owner, other] = await ethers.getSigners();
+
+    const MockVerifier = await ethers.getContractFactory("MockTrainingAttestationVerifier");
+    mockVerifier = await MockVerifier.deploy();
+    await mockVerifier.waitForDeployment();
+    verifierAddr = await mockVerifier.getAddress();
+
+    const Hook = await ethers.getContractFactory("ERC721AIAttestationHook");
+    hook = await Hook.deploy(owner.address);
+    await hook.waitForDeployment();
+  });
+
+  describe("Deployment", function () {
+    it("sets owner on deploy", async function () {
+      expect(await hook.owner()).to.equal(owner.address);
+    });
+  });
+
+  describe("setAttestationVerifier", function () {
+    it("configures a verifier for an attestation kind", async function () {
+      await expect(hook.setAttestationVerifier(ATTESTATION_KIND, verifierAddr))
+        .to.emit(hook, "AttestationVerifierConfigured")
+        .withArgs(ATTESTATION_KIND, verifierAddr);
+      expect(await hook.attestationVerifiers(ATTESTATION_KIND)).to.equal(verifierAddr);
+    });
+
+    it("reverts when called by non-owner", async function () {
+      await expect(
+        hook.connect(other).setAttestationVerifier(ATTESTATION_KIND, verifierAddr)
+      ).to.be.revertedWithCustomError(hook, "NotOwner");
+    });
+
+    it("reverts with zero address verifier", async function () {
+      await expect(
+        hook.setAttestationVerifier(ATTESTATION_KIND, ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(hook, "ZeroAddressVerifier");
+    });
+  });
+
+  describe("registerAndVerifyAttestation", function () {
+    const tokenId = 1;
+    const modelId = ethers.encodeBytes32String("model-1");
+    const artifactHash = ethers.encodeBytes32String("artifact-1");
+    const attestationData = ethers.toUtf8Bytes("test-attestation");
+
+    beforeEach(async function () {
+      await hook.setAttestationVerifier(ATTESTATION_KIND, verifierAddr);
+    });
+
+    it("registers a verified attestation", async function () {
+      await mockVerifier.setApproval(modelId, artifactHash, attestationData, true);
+      await expect(
+        hook.registerAndVerifyAttestation(tokenId, modelId, artifactHash, ATTESTATION_KIND, attestationData)
+      ).to.emit(hook, "TrainingAttestationVerified");
+      const att = await hook.attestationsByTokenId(tokenId);
+      expect(att.modelId).to.equal(modelId);
+      expect(att.artifactHash).to.equal(artifactHash);
+      expect(att.verifier).to.equal(verifierAddr);
+    });
+
+    it("reverts when verifier not configured", async function () {
+      const unknownKind = ethers.encodeBytes32String("unknown");
+      await expect(
+        hook.registerAndVerifyAttestation(tokenId, modelId, artifactHash, unknownKind, attestationData)
+      ).to.be.revertedWithCustomError(hook, "MissingVerifier");
+    });
+
+    it("reverts when verification fails", async function () {
+      await expect(
+        hook.registerAndVerifyAttestation(tokenId, modelId, artifactHash, ATTESTATION_KIND, attestationData)
+      ).to.be.revertedWithCustomError(hook, "AttestationVerificationFailed");
+    });
+
+    it("works with acceptAll mode", async function () {
+      await mockVerifier.setAcceptAll(true);
+      await expect(
+        hook.registerAndVerifyAttestation(tokenId, modelId, artifactHash, ATTESTATION_KIND, attestationData)
+      ).to.emit(hook, "TrainingAttestationVerified");
+    });
+
+    it("stores correct attestation hash", async function () {
+      await mockVerifier.setAcceptAll(true);
+      await hook.registerAndVerifyAttestation(tokenId, modelId, artifactHash, ATTESTATION_KIND, attestationData);
+      const att = await hook.attestationsByTokenId(tokenId);
+      expect(att.attestationHash).to.equal(ethers.keccak256(attestationData));
+    });
+
+    it("allows overwriting attestation for same token", async function () {
+      await mockVerifier.setAcceptAll(true);
+      await hook.registerAndVerifyAttestation(tokenId, modelId, artifactHash, ATTESTATION_KIND, attestationData);
+      const newData = ethers.toUtf8Bytes("updated");
+      await hook.registerAndVerifyAttestation(tokenId, modelId, artifactHash, ATTESTATION_KIND, newData);
+      const att = await hook.attestationsByTokenId(tokenId);
+      expect(att.attestationHash).to.equal(ethers.keccak256(newData));
+    });
+
+    it("anyone can register if verifier configured", async function () {
+      await mockVerifier.setAcceptAll(true);
+      await expect(
+        hook.connect(other).registerAndVerifyAttestation(1, modelId, artifactHash, ATTESTATION_KIND, attestationData)
+      ).to.emit(hook, "TrainingAttestationVerified");
+    });
+  });
+});


### PR DESCRIPTION
## What this does

Adds a full Foundry test suite for the ERC721AIAttestationHook contract as specified in #5.

### Test Coverage (15 tests, all passing)

**Deployment**
- Owner set correctly

**setAttestationVerifier**
- Configure verifier for attestation kind
- Emit AttestationVerifierConfigured event
- Revert when non-owner calls
- Revert with zero address
- Update existing verifier

**registerAndVerifyAttestation**
- Register verified attestation with correct storage
- Revert when verifier not configured
- Revert when verification fails
- Work with acceptAll mode
- Emit TrainingAttestationVerified event
- Allow overwriting attestation for same token
- Allow anyone to register if verifier set

**Multiple**
- Multiple token attestations independent
- Multiple attestation kinds (ZK-TEE, SGX)

### Setup
- Foundry with solc 0.8.24
- forge-std dependency
- Also includes Hardhat/ethers.js test file for JS contributors

```bash
forge test   # 15 passed
```

Closes #5