### PR TITLE
feat: add off-chain weight storage integration (IPFS + Arweave)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,71 @@
+# Off-chain Weight Storage Integration
+
+This directory contains scripts for uploading AI model weights to IPFS or Arweave, generating token metadata, and minting ERC721AI tokens.
+
+## Files
+
+- `upload_weights.py` - Upload weights and generate metadata
+- `mint_token.py` - One-flow: upload + mint
+
+## Quick Start
+
+### Upload weights to IPFS
+
+```bash
+python scripts/upload_weights.py \
+    --weights ./model.weights \
+    --storage ipfs \
+    --architecture "GPT-2 based model" \
+    --output ./metadata.json
+```
+
+### Upload weights to Arweave
+
+```bash
+python scripts/upload_weights.py \
+    --weights ./model.weights \
+    --storage arweave \
+    --arweave-wallet ./wallet.json \
+    --output ./metadata.json
+```
+
+### One-flow: Upload and Mint
+
+```bash
+python scripts/mint_token.py \
+    --weights ./model.weights \
+    --storage ipfs \
+    --contract 0x1234567890123456789012345678901234567890 \
+    --private-key 0xabcd... \
+    --architecture "BERT fine-tuned model"
+```
+
+## Requirements
+
+```bash
+pip install ipfshttpclient arweave web3 eth_account
+```
+
+## Output Format
+
+The metadata JSON follows ERC721AI tokenURI spec:
+
+```json
+{
+  "name": "AI Model a1b2c3d4",
+  "description": "Tokenized AI model weights stored on IPFS",
+  "properties": {
+    "model_hash": "sha256:abc123...",
+    "model_hash_algorithm": "SHA-256",
+    "storage_cid": "QmXxx...",
+    "storage_type": "IPFS",
+    "architecture": "GPT-2 based model",
+    "file_size_bytes": 12345678,
+    "training_dataset_hash": "sha256:def456..."
+  }
+}
+```
+
+## Related Issue
+
+This implementation addresses: https://github.com/kcolbchain/erc721-ai/issues/4

--- a/scripts/mint_token.py
+++ b/scripts/mint_token.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+One-flow script: Upload weights to IPFS/Arweave and mint ERC721AI token.
+
+This script combines:
+1. Uploading weights to off-chain storage
+2. Generating token metadata
+3. Minting the token (requires contract interaction)
+
+Usage:
+    python scripts/mint_oneflow.py \
+        --weights ./model.weights \
+        --contract 0x1234... \
+        --private-key 0xabcd... \
+        --arweave
+
+Requirements:
+    pip install web3 arweave eth_account
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from upload_weights import upload_and_mint
+
+
+def mint_token(
+    contract_address: str,
+    token_uri: str,
+    private_key: str,
+    rpc_url: str = "http://localhost:8545"
+) -> str:
+    """Mint ERC721AI token with the given URI."""
+    try:
+        from web3 import Web3
+        from eth_account import Account
+    except ImportError:
+        print("❌ web3 or eth_account not installed")
+        print("   Run: pip install web3 eth_account")
+        sys.exit(1)
+    
+    w3 = Web3(Web3.HTTPProvider(rpc_url))
+    if not w3.is_connected():
+        print(f"❌ Cannot connect to RPC: {rpc_url}")
+        sys.exit(1)
+    
+    account = Account.from_key(private_key)
+    print(f"   Account: {account.address}")
+    
+    # ERC721AI contract ABI (minimal for minting)
+    abi = [
+        {
+            "inputs": [
+                {"name": "to", "type": "address"},
+                {"name": "tokenURI", "type": "string"}
+            ],
+            "name": "mint",
+            "outputs": [{"name": "tokenId", "type": "uint256"}],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        }
+    ]
+    
+    contract = w3.eth.contract(address=contract_address, abi=abi)
+    
+    nonce = w3.eth.get_transaction_count(account.address)
+    tx = contract.functions.mint(account.address, token_uri).build_transaction({
+        'from': account.address,
+        'nonce': nonce,
+        'gas': 200000,
+        'gasPrice': w3.eth.gas_price
+    })
+    
+    signed_tx = account.sign_transaction(tx)
+    tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+    
+    token_id = receipt.logs[0]['topics'][3] if receipt.logs else "unknown"
+    return token_id
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Upload weights and mint ERC721AI token")
+    parser.add_argument("--weights", required=True, help="Path to model weights file")
+    parser.add_argument("--storage", choices=["ipfs", "arweave"], default="ipfs")
+    parser.add_argument("--contract", required=True, help="ERC721AI contract address")
+    parser.add_argument("--private-key", required=True, help="Wallet private key")
+    parser.add_argument("--rpc-url", default="http://localhost:8545", help="RPC URL")
+    parser.add_argument("--arweave-wallet", help="Arweave wallet path")
+    parser.add_argument("--architecture", default="Transformer-based model")
+    parser.add_argument("--dataset", help="Training dataset path")
+    parser.add_argument("--model-name", help="Model name")
+    parser.add_argument("--output-dir", default="./output", help="Output directory")
+    
+    args = parser.parse_args()
+    
+    os.makedirs(args.output_dir, exist_ok=True)
+    metadata_path = f"{args.output_dir}/metadata.json"
+    
+    print("🚀 ERC721AI One-Flow: Upload + Mint")
+    print("=" * 50)
+    
+    print("\n📤 Step 1: Uploading weights...")
+    result = upload_and_mint(
+        weights_path=args.weights,
+        storage=args.storage,
+        architecture=args.architecture,
+        dataset_path=args.dataset,
+        arweave_wallet=args.arweave_wallet,
+        output=metadata_path
+    )
+    
+    print("\n⛓️  Step 2: Minting token...")
+    token_id = mint_token(
+        contract_address=args.contract,
+        token_uri=f"ipfs://{result['storage_cid']}",
+        private_key=args.private_key,
+        rpc_url=args.rpc_url
+    )
+    
+    print(f"\n✅ Token minted!")
+    print(f"   Token ID: {token_id}")
+    print(f"   Metadata: {metadata_path}")
+
+
+if __name__ == "__main__":
+    import os
+    main()

--- a/scripts/upload_weights.py
+++ b/scripts/upload_weights.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+Off-chain Weight Storage Integration for ERC721AI
+Uploads model weights to IPFS or Arweave and generates token metadata.
+
+Usage:
+    python scripts/upload_weights.py --weights ./model.weights --arweave
+    python scripts/upload_weights.py --weights ./model.weights --ipfs
+    python scripts/upload_weights.py --weights ./model.weights --ipfs --dataset ./dataset.tar.gz
+
+Requirements:
+    pip install ipfshttpclient arweave
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+try:
+    import ipfshttpclient
+    HAS_IPFS = True
+except ImportError:
+    HAS_IPFS = False
+
+try:
+    import arweave
+    HAS_ARWEAVE = True
+except ImportError:
+    HAS_ARWEAVE = False
+
+
+def calculate_sha256(file_path: str) -> str:
+    """Calculate SHA-256 hash of a file."""
+    sha256_hash = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for byte_block in iter(lambda: f.read(4096), b""):
+            sha256_hash.update(byte_block)
+    return sha256_hash.hexdigest()
+
+
+def upload_to_ipfs(file_path: str, api_url: str = "/dns/localhost/tcp/5001") -> str:
+    """Upload file to IPFS and return CID."""
+    if not HAS_IPFS:
+        raise ImportError("ipfshttpclient not installed. Run: pip install ipfshttpclient")
+    
+    with ipfshttpclient.connect(api_url) as client:
+        result = client.add(file_path)
+        return result["Hash"]
+
+
+def upload_to_arweave(file_path: str, wallet_path: str = None) -> str:
+    """Upload file to Arweave and return transaction ID."""
+    if not HAS_ARWEAVE:
+        raise ImportError("arweave not installed. Run: pip install arweave")
+    
+    if wallet_path and os.path.exists(wallet_path):
+        with open(wallet_path) as f:
+            wallet = json.load(f)
+        client = arweave.Wallet.from_json(wallet)
+    else:
+        client = arweave.Wallet()
+    
+    with open(file_path, "rb") as f:
+        data = f.read()
+    
+    tx = client.create_transaction(
+        data=data,
+        file_path=file_path,
+        content_type="application/octet-stream"
+    )
+    client.send_transaction(tx)
+    return tx["id"]
+
+
+def generate_metadata(
+    weights_path: str,
+    storage_cid: str,
+    storage_type: str,
+    architecture: str = "unknown",
+    dataset_hash: str = None,
+    model_name: str = None
+) -> dict:
+    """Generate token metadata JSON matching ERC721AI tokenURI spec."""
+    
+    weights_hash = calculate_sha256(weights_path)
+    file_size = os.path.getsize(weights_path)
+    
+    metadata = {
+        "name": model_name or f"AI Model {weights_hash[:8]}",
+        "description": f"Tokenized AI model weights stored on {storage_type}",
+        "properties": {
+            "model_hash": weights_hash,
+            "model_hash_algorithm": "SHA-256",
+            "storage_cid": storage_cid,
+            "storage_type": storage_type,
+            "architecture": architecture,
+            "file_size_bytes": file_size,
+        }
+    }
+    
+    if dataset_hash:
+        metadata["properties"]["training_dataset_hash"] = dataset_hash
+    
+    return metadata
+
+
+def upload_and_mint(
+    weights_path: str,
+    storage: str = "ipfs",
+    architecture: str = None,
+    dataset_path: str = None,
+    ipfs_api: str = "/dns/localhost/tcp/5001",
+    arweave_wallet: str = None,
+    output: str = None
+) -> dict:
+    """
+    Main function: upload weights, generate metadata, optionally mint token.
+    
+    Returns dict with:
+        - metadata: token metadata JSON
+        - storage_cid: IPFS CID or Arweave TX ID
+        - weights_hash: SHA-256 of weights file
+    """
+    
+    if not os.path.exists(weights_path):
+        raise FileNotFoundError(f"Weights file not found: {weights_path}")
+    
+    print(f"📊 Calculating SHA-256 hash of {weights_path}...")
+    weights_hash = calculate_sha256(weights_path)
+    print(f"   Hash: {weights_hash}")
+    
+    print(f"☁️  Uploading to {storage}...")
+    if storage == "ipfs":
+        storage_cid = upload_to_ipfs(weights_path, ipfs_api)
+        storage_type = "IPFS"
+    elif storage == "arweave":
+        storage_cid = upload_to_arweave(weights_path, arweave_wallet)
+        storage_type = "Arweave"
+    else:
+        raise ValueError(f"Unknown storage type: {storage}")
+    
+    print(f"   CID/TX ID: {storage_cid}")
+    
+    dataset_hash = None
+    if dataset_path:
+        print(f"📊 Calculating dataset hash...")
+        dataset_hash = calculate_sha256(dataset_path)
+        print(f"   Dataset Hash: {dataset_hash}")
+    
+    print(f"📝 Generating metadata...")
+    metadata = generate_metadata(
+        weights_path=weights_path,
+        storage_cid=storage_cid,
+        storage_type=storage_type,
+        architecture=architecture,
+        dataset_hash=dataset_hash
+    )
+    
+    print(f"   Metadata: {json.dumps(metadata, indent=2)}")
+    
+    metadata_bytes = json.dumps(metadata, indent=2).encode()
+    metadata_hash = hashlib.sha256(metadata_bytes).hexdigest()
+    print(f"   Metadata hash: {metadata_hash}")
+    
+    if output:
+        output_path = Path(output)
+        output_path.write_text(json.dumps(metadata, indent=2))
+        print(f"💾 Metadata saved to: {output}")
+        
+        metadata_cid_path = output_path.parent / f"{output_path.stem}_metadata.json"
+        if storage == "ipfs":
+            with ipfshttpclient.connect(ipfs_api) as client:
+                result = client.add(output_path)
+                metadata_cid = result["Hash"]
+            print(f"☁️  Metadata uploaded to IPFS: {metadata_cid}")
+            with open(metadata_cid_path, "w") as f:
+                json.dump({"metadata_cid": metadata_cid, "weights_cid": storage_cid}, f, indent=2)
+            print(f"💾 CID references saved to: {metadata_cid_path}")
+    
+    return {
+        "metadata": metadata,
+        "storage_cid": storage_cid,
+        "storage_type": storage_type,
+        "weights_hash": weights_hash
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Upload AI model weights to IPFS/Arweave")
+    parser.add_argument("--weights", required=True, help="Path to model weights file")
+    parser.add_argument("--storage", choices=["ipfs", "arweave"], default="ipfs",
+                        help="Storage backend (default: ipfs)")
+    parser.add_argument("--arweave-wallet", help="Path to Arweave wallet JSON")
+    parser.add_argument("--ipfs-api", default="/dns/localhost/tcp/5001",
+                        help="IPFS API endpoint")
+    parser.add_argument("--architecture", default="unknown",
+                        help="Model architecture description")
+    parser.add_argument("--dataset", help="Path to training dataset for hashing")
+    parser.add_argument("--model-name", help="Model name for metadata")
+    parser.add_argument("--output", help="Output file for metadata JSON")
+    
+    args = parser.parse_args()
+    
+    result = upload_and_mint(
+        weights_path=args.weights,
+        storage=args.storage,
+        architecture=args.architecture,
+        dataset_path=args.dataset,
+        ipfs_api=args.ipfs_api,
+        arweave_wallet=args.arweave_wallet,
+        output=args.output
+    )
+    
+    print("\n✅ Upload complete!")
+    print(f"\n📋 Summary:")
+    print(f"   Storage: {result['storage_type']}")
+    print(f"   CID/TX ID: {result['storage_cid']}")
+    print(f"   Weights Hash: {result['weights_hash']}")
+    print(f"\n🔗 Use this CID as the storage_cid in your ERC721AI tokenURI")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements off-chain weight storage integration (Issue #4).

### Changes
- scripts/upload_weights.py - IPFS/Arweave upload + metadata
- scripts/mint_token.py - One-flow upload + mint
- scripts/README.md - Documentation

### Usage
python scripts/upload_weights.py --weights ./model.weights --ipfs

### Closes
Closes #4