### PR TITLE
chore: add Dependabot for pip and npm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Adds Dependabot configuration to automatically keep pip and npm dependencies up to date.

## Changes

- .github/dependabot.yml — Dependabot config for:
  - pip packages (weekly schedule, up to 10 PRs)
  - npm packages (weekly schedule, up to 5 PRs)

## Why

Dependabot catches vulnerable/outdated dependencies automatically, reducing security debt.

## Bounty

This PR also claims bounty #1613 (Set up Dependabot for any Elyan Labs repo, 3 RTC) if applicable.

RTC Wallet: chenzhizhuan