### PR TITLE
spec: ERC-721 AI v0 draft + reference contract (closes #1, #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,20 @@ cd erc721-ai
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started. Issues tagged `good-first-issue` are great entry points.
 
+## Draft Specification
+
+The v0 draft of the ERC-721 AI standard is in [`docs/spec-erc721-ai.md`](docs/spec-erc721-ai.md). It defines the metadata schema (model id, weights CID, artifact hash, base-model provenance, license, inference endpoint, royalty), the required interface, and the ERC-2981 + attestation-hook integration.
+
+## Reference Implementation
+
+- `contracts/ERC721AI.sol` — minimal, dependency-free reference that implements the full ERC-721 AI surface (`mintModel`, `modelAsset`, `setInferenceEndpoint`, `setAttestationKind`, `royaltyInfo`) plus the ERC-721 subset needed for it to render in standard wallets.
+- `test/ERC721AI.t.sol` — Foundry tests covering mint, provenance chain lookup, royalties, endpoint mutation, attestation kind mutation, transfer semantics, and revert paths.
+
+Production deployments SHOULD substitute an audited ERC-721 base (OpenZeppelin) and inherit `ERC721AI` behavior — this reference optimizes for clarity, not bytecode size.
+
 ## Attestation Hook (ZK / TEE)
 
-This repo includes a pluggable contract-level attestation hook for verifiable training claims:
+This repo also includes a pluggable contract-level attestation hook for verifiable training claims:
 
 - `contracts/interfaces/ITrainingAttestationVerifier.sol`
 - `contracts/mocks/MockTrainingAttestationVerifier.sol`

--- a/contracts/ERC721AI.sol
+++ b/contracts/ERC721AI.sol
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title ERC721AI — reference implementation of the ERC-721 AI model-asset standard.
+/// @notice Self-contained: implements the ERC-721 subset this standard needs plus
+///         ERC-2981 royalties, without external dependencies. Production deployments
+///         SHOULD substitute a fully audited ERC-721 base (OpenZeppelin) — this
+///         implementation optimizes for clarity and testability, not bytecode size.
+/// @dev See `docs/spec-erc721-ai.md` for the full specification.
+contract ERC721AI {
+    // ─── ERC-721 minimal surface ─────────────────────────────────────────
+
+    string public name;
+    string public symbol;
+
+    mapping(uint256 => address) private _owners;
+    mapping(address => uint256) private _balances;
+    mapping(uint256 => address) private _tokenApprovals;
+    mapping(address => mapping(address => bool)) private _operatorApprovals;
+
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    // ─── ERC-721 AI model-asset surface ──────────────────────────────────
+
+    struct ModelAsset {
+        bytes32 modelId;
+        bytes32 artifactHash;
+        bytes32 baseModel;
+        string  weightsCID;
+        string  architecture;
+        string  license;
+        string  inferenceEndpoint;
+        bytes32 attestationKind;
+        uint16  creatorRoyaltyBps;
+        uint64  createdAt;
+        address creator;
+    }
+
+    /// @dev tokenId → model-asset record.
+    mapping(uint256 => ModelAsset) private _assets;
+
+    /// @dev modelId → tokenId. Used for provenance-chain traversal.
+    mapping(bytes32 => uint256) public tokenIdByModelId;
+
+    /// @dev Incrementing counter. tokenIds start at 1 (zero is reserved for "absent").
+    uint256 public totalSupply;
+
+    event ModelMinted(
+        uint256 indexed tokenId,
+        bytes32 indexed modelId,
+        bytes32 indexed artifactHash,
+        address creator,
+        string weightsCID
+    );
+
+    event InferenceEndpointUpdated(uint256 indexed tokenId, string endpoint);
+    event AttestationKindUpdated(uint256 indexed tokenId, bytes32 kind);
+
+    // ─── Errors ───────────────────────────────────────────────────────────
+
+    error NotOwnerOrApproved();
+    error TokenDoesNotExist();
+    error InvalidRecipient();
+    error ModelIdAlreadyMinted();
+    error ZeroArtifactHash();
+    error ZeroModelId();
+    error RoyaltyTooHigh();
+    error BaseModelNotFound();
+    error NotTokenOwner();
+
+    // ─── Constructor ──────────────────────────────────────────────────────
+
+    constructor(string memory name_, string memory symbol_) {
+        name = name_;
+        symbol = symbol_;
+    }
+
+    // ─── ERC-721 AI public API ───────────────────────────────────────────
+
+    /// @notice Mint a new model-asset token.
+    /// @dev Reverts if `modelId` has already been minted, if `artifactHash` or
+    ///      `modelId` is zero, if `creatorRoyaltyBps > 10000`, or if a non-zero
+    ///      `baseModel` does not resolve to an existing token on this contract.
+    function mintModel(
+        address to,
+        bytes32 modelId,
+        bytes32 artifactHash,
+        bytes32 baseModel,
+        string calldata weightsCID,
+        string calldata architecture,
+        string calldata license,
+        string calldata inferenceEndpoint,
+        uint16 creatorRoyaltyBps
+    ) external returns (uint256 tokenId) {
+        if (to == address(0)) revert InvalidRecipient();
+        if (modelId == bytes32(0)) revert ZeroModelId();
+        if (artifactHash == bytes32(0)) revert ZeroArtifactHash();
+        if (tokenIdByModelId[modelId] != 0) revert ModelIdAlreadyMinted();
+        if (creatorRoyaltyBps > 10_000) revert RoyaltyTooHigh();
+        if (baseModel != bytes32(0) && tokenIdByModelId[baseModel] == 0) revert BaseModelNotFound();
+
+        unchecked {
+            totalSupply += 1;
+        }
+        tokenId = totalSupply;
+
+        _assets[tokenId] = ModelAsset({
+            modelId: modelId,
+            artifactHash: artifactHash,
+            baseModel: baseModel,
+            weightsCID: weightsCID,
+            architecture: architecture,
+            license: license,
+            inferenceEndpoint: inferenceEndpoint,
+            attestationKind: bytes32(0),
+            creatorRoyaltyBps: creatorRoyaltyBps,
+            createdAt: uint64(block.timestamp),
+            creator: msg.sender
+        });
+
+        tokenIdByModelId[modelId] = tokenId;
+
+        _mint(to, tokenId);
+
+        emit ModelMinted(tokenId, modelId, artifactHash, msg.sender, weightsCID);
+    }
+
+    /// @notice Read a model-asset record.
+    function modelAsset(uint256 tokenId) external view returns (
+        bytes32 modelId,
+        bytes32 artifactHash,
+        bytes32 baseModel,
+        string memory weightsCID,
+        string memory architecture,
+        string memory license,
+        string memory inferenceEndpoint,
+        uint16 creatorRoyaltyBps,
+        uint64 createdAt,
+        address creator
+    ) {
+        if (_owners[tokenId] == address(0)) revert TokenDoesNotExist();
+        ModelAsset storage m = _assets[tokenId];
+        return (
+            m.modelId,
+            m.artifactHash,
+            m.baseModel,
+            m.weightsCID,
+            m.architecture,
+            m.license,
+            m.inferenceEndpoint,
+            m.creatorRoyaltyBps,
+            m.createdAt,
+            m.creator
+        );
+    }
+
+    /// @notice Update the inference endpoint. Only the current token owner may call.
+    function setInferenceEndpoint(uint256 tokenId, string calldata endpoint) external {
+        if (_owners[tokenId] == address(0)) revert TokenDoesNotExist();
+        if (_owners[tokenId] != msg.sender) revert NotTokenOwner();
+        _assets[tokenId].inferenceEndpoint = endpoint;
+        emit InferenceEndpointUpdated(tokenId, endpoint);
+    }
+
+    /// @notice Set the attestation kind for a token. Only the original creator may call.
+    /// @dev Intended to be called by (or on behalf of) the creator after an attestation
+    ///      has been registered in the `ERC721AIAttestationHook`. The hook enforces
+    ///      the actual cryptographic verification; this setter records which kind
+    ///      of attestation accompanies the token for discovery.
+    function setAttestationKind(uint256 tokenId, bytes32 kind) external {
+        if (_owners[tokenId] == address(0)) revert TokenDoesNotExist();
+        if (_assets[tokenId].creator != msg.sender) revert NotOwnerOrApproved();
+        _assets[tokenId].attestationKind = kind;
+        emit AttestationKindUpdated(tokenId, kind);
+    }
+
+    // ─── ERC-2981 royalties ──────────────────────────────────────────────
+
+    /// @notice ERC-2981 royalty info.
+    function royaltyInfo(uint256 tokenId, uint256 salePrice)
+        external
+        view
+        returns (address receiver, uint256 royaltyAmount)
+    {
+        if (_owners[tokenId] == address(0)) revert TokenDoesNotExist();
+        ModelAsset storage m = _assets[tokenId];
+        receiver = m.creator;
+        royaltyAmount = (salePrice * uint256(m.creatorRoyaltyBps)) / 10_000;
+    }
+
+    // ─── ERC-165 / interface support ─────────────────────────────────────
+
+    /// @dev Minimal ERC-165. Returns true for ERC-721 (0x80ac58cd), ERC-165
+    ///      (0x01ffc9a7), and ERC-2981 (0x2a55205a). Does NOT return true for
+    ///      ERC721TokenReceiver or enumerable extensions — those are out of
+    ///      scope for v0.
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == 0x01ffc9a7 // ERC-165
+            || interfaceId == 0x80ac58cd // ERC-721
+            || interfaceId == 0x5b5e139f // ERC-721 Metadata
+            || interfaceId == 0x2a55205a; // ERC-2981
+    }
+
+    // ─── ERC-721 standard functions ──────────────────────────────────────
+
+    function balanceOf(address owner) external view returns (uint256) {
+        if (owner == address(0)) revert InvalidRecipient();
+        return _balances[owner];
+    }
+
+    function ownerOf(uint256 tokenId) public view returns (address) {
+        address owner = _owners[tokenId];
+        if (owner == address(0)) revert TokenDoesNotExist();
+        return owner;
+    }
+
+    function approve(address to, uint256 tokenId) external {
+        address owner = ownerOf(tokenId);
+        if (msg.sender != owner && !_operatorApprovals[owner][msg.sender]) revert NotOwnerOrApproved();
+        _tokenApprovals[tokenId] = to;
+        emit Approval(owner, to, tokenId);
+    }
+
+    function getApproved(uint256 tokenId) external view returns (address) {
+        if (_owners[tokenId] == address(0)) revert TokenDoesNotExist();
+        return _tokenApprovals[tokenId];
+    }
+
+    function setApprovalForAll(address operator, bool approved) external {
+        _operatorApprovals[msg.sender][operator] = approved;
+        emit ApprovalForAll(msg.sender, operator, approved);
+    }
+
+    function isApprovedForAll(address owner, address operator) external view returns (bool) {
+        return _operatorApprovals[owner][operator];
+    }
+
+    function transferFrom(address from, address to, uint256 tokenId) public {
+        if (!_isApprovedOrOwner(msg.sender, tokenId)) revert NotOwnerOrApproved();
+        if (to == address(0)) revert InvalidRecipient();
+        if (_owners[tokenId] != from) revert NotOwnerOrApproved();
+
+        // Clear approvals.
+        delete _tokenApprovals[tokenId];
+
+        unchecked {
+            _balances[from] -= 1;
+            _balances[to] += 1;
+        }
+        _owners[tokenId] = to;
+
+        emit Transfer(from, to, tokenId);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId) external {
+        transferFrom(from, to, tokenId);
+        // NOTE: we do not call onERC721Received here because the reference impl
+        // intentionally stays minimal. Production deployments that extend this
+        // should re-instate the ERC721Receiver hook.
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata /* data */) external {
+        transferFrom(from, to, tokenId);
+    }
+
+    // ─── Internals ────────────────────────────────────────────────────────
+
+    function _mint(address to, uint256 tokenId) internal {
+        unchecked {
+            _balances[to] += 1;
+        }
+        _owners[tokenId] = to;
+        emit Transfer(address(0), to, tokenId);
+    }
+
+    function _isApprovedOrOwner(address spender, uint256 tokenId) internal view returns (bool) {
+        address owner = _owners[tokenId];
+        if (owner == address(0)) revert TokenDoesNotExist();
+        return spender == owner
+            || _tokenApprovals[tokenId] == spender
+            || _operatorApprovals[owner][spender];
+    }
+}

--- a/docs/spec-erc721-ai.md
+++ b/docs/spec-erc721-ai.md
@@ -1,0 +1,177 @@
+# ERC-721 AI — Draft Token Standard Specification
+
+**Status:** Draft (2026-04-18)
+**Authors:** kcolbchain
+**Addresses:** `kcolbchain/erc721-ai#1`, `kcolbchain/erc721-ai#2`
+**Extends:** [ERC-721](https://eips.ethereum.org/EIPS/eip-721)
+**References:** [ERC-4906 (metadata update)](https://eips.ethereum.org/EIPS/eip-4906), [ERC-5192 (soulbound)](https://eips.ethereum.org/EIPS/eip-5192), [ERC-2981 (royalties)](https://eips.ethereum.org/EIPS/eip-2981), `kcolbchain/erc721-ai` attestation-hook extension.
+
+---
+
+## 1. Abstract
+
+ERC-721 AI is a token standard for tokenized AI model weights. Each token represents **one model asset**: a fine-tuned or base model identified by a content-addressed artifact hash, with its ownership, provenance, inference endpoint, and license recorded on-chain in a standardized way.
+
+It intentionally stays within the ERC-721 interface so model-asset NFTs render in every existing NFT wallet, marketplace, and indexer. Verifiability (did this model actually train on what the metadata claims?) is handled by the separate attestation-hook extension already in this repo; this spec defines only the **asset layer**.
+
+## 2. Motivation
+
+The AI model ecosystem today has three weak points that a token standard addresses cleanly:
+
+1. **Ownership** — HuggingFace model pages list a single "author"; there is no way to split ownership between the dataset curator, the fine-tuner, and the infrastructure provider. ERC-721 AI encodes ownership in the token and royalties via ERC-2981.
+2. **Provenance** — a downstream user of `some-fine-tuned-llama-3` has no on-chain record of which base model was fine-tuned, on what data, or with what parameters. ERC-721 AI records a **provenance chain** (pointer to parent model token + fine-tuning receipt hash).
+3. **Access / monetization** — running inference against a fine-tuned model today requires a bespoke endpoint + API key arrangement per model. ERC-721 AI exposes a standard `inferenceEndpoint()` URI and couples cleanly with the separate x402 per-inference metering work (see `#9`).
+
+ERC-721 AI is **not** a container for model weights. Weights are stored off-chain (IPFS / Arweave / HuggingFace / private). The token records the *hash* of the weights and the *pointer* to them.
+
+## 3. Specification
+
+### 3.1 Required metadata fields
+
+Every ERC-721 AI token MUST expose the following fields, either on-chain via the reference contract's `modelAsset(tokenId)` getter, or in the `tokenURI` JSON per ERC-721 convention.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `modelId` | `bytes32` | Yes | Canonical model identifier. Typically `keccak256(<creator addr> \|\| <weights CID>)`; MAY be any globally-unique identifier. |
+| `weightsCID` | `string` | Yes | Content identifier for the model weights (IPFS CID, Arweave tx id, HuggingFace repo + revision, or HTTPS URL). |
+| `artifactHash` | `bytes32` | Yes | `keccak256` of the serialized weights artifact. This is the **hash that locks the token to specific weights**. |
+| `baseModel` | `bytes32` | No | `modelId` of the parent model, if this is a fine-tune. Zero means "no parent declared." |
+| `architecture` | `string` | Yes | Free-form architecture name (`llama-3.1-70b-instruct`, `sdxl-base-1.0`, `custom-mixture-of-experts`, etc). |
+| `license` | `string` | Yes | SPDX-compatible license identifier (`MIT`, `Apache-2.0`, `LLAMA3-COMMUNITY`, `PROPRIETARY`). |
+| `inferenceEndpoint` | `string` | No | HTTPS / onion / decentralized endpoint URL where inference against this model is served. Empty string if none. |
+| `attestationKind` | `bytes32` | No | If an attestation is registered in the attestation-hook, the kind (`ZK_PROOF`, `TEE_SIG`, etc). |
+| `creatorRoyaltyBps` | `uint16` | Yes | Basis points of secondary-sale proceeds owed to the creator per ERC-2981. |
+| `createdAt` | `uint64` | Yes | Block timestamp at mint. |
+
+### 3.2 On-chain struct layout (reference)
+
+```solidity
+struct ModelAsset {
+    bytes32 modelId;
+    bytes32 artifactHash;
+    bytes32 baseModel;        // parent modelId, or zero
+    string  weightsCID;
+    string  architecture;
+    string  license;
+    string  inferenceEndpoint;
+    bytes32 attestationKind;
+    uint16  creatorRoyaltyBps;
+    uint64  createdAt;
+    address creator;          // original minter; immutable
+}
+```
+
+The `creator` field is stored separately from the ERC-721 owner so royalties stay with the creator after a transfer.
+
+### 3.3 Token URI JSON schema
+
+`tokenURI(tokenId)` SHOULD return JSON conformant to the following schema. Existing marketplaces will render the `name`, `description`, `image` fields; ERC-721 AI-aware tooling SHOULD additionally parse the `model` object.
+
+```json
+{
+  "name": "Llama-3.1-70B fine-tune on legal corpus v1",
+  "description": "LoRA fine-tune on 1.4M legal documents.",
+  "image": "ipfs://bafy.../card.png",
+  "model": {
+    "modelId": "0x…",
+    "weightsCID": "ipfs://bafy.../weights/",
+    "artifactHash": "0x…",
+    "baseModel": "0x…",
+    "architecture": "llama-3.1-70b-instruct",
+    "license": "LLAMA3-COMMUNITY",
+    "inferenceEndpoint": "https://inf.example.org/models/0x…",
+    "attestationKind": "0x…",
+    "creatorRoyaltyBps": 500,
+    "createdAt": 1797609600,
+    "creator": "0x…"
+  }
+}
+```
+
+### 3.4 Required interface
+
+```solidity
+interface IERC721AI /* is IERC721, IERC2981 */ {
+    event ModelMinted(
+        uint256 indexed tokenId,
+        bytes32 indexed modelId,
+        bytes32 indexed artifactHash,
+        address creator,
+        string weightsCID
+    );
+
+    event InferenceEndpointUpdated(uint256 indexed tokenId, string endpoint);
+
+    function mintModel(
+        address to,
+        bytes32 modelId,
+        bytes32 artifactHash,
+        bytes32 baseModel,
+        string calldata weightsCID,
+        string calldata architecture,
+        string calldata license,
+        string calldata inferenceEndpoint,
+        uint16 creatorRoyaltyBps
+    ) external returns (uint256 tokenId);
+
+    function modelAsset(uint256 tokenId) external view returns (
+        bytes32 modelId,
+        bytes32 artifactHash,
+        bytes32 baseModel,
+        string memory weightsCID,
+        string memory architecture,
+        string memory license,
+        string memory inferenceEndpoint,
+        uint16 creatorRoyaltyBps,
+        uint64 createdAt,
+        address creator
+    );
+
+    function setInferenceEndpoint(uint256 tokenId, string calldata endpoint) external;
+}
+```
+
+### 3.5 Provenance chain
+
+When `baseModel` is non-zero, it MUST reference an existing ERC-721 AI token's `modelId` **on the same contract**. Implementations MAY relax this to allow cross-contract references in a later revision; v0 keeps it same-contract for unambiguous chain traversal.
+
+A downstream indexer can walk the provenance chain by repeatedly looking up `modelAsset(tokenId).baseModel → find token with that modelId → ...` until `baseModel == 0`.
+
+### 3.6 Royalties
+
+ERC-721 AI MUST implement ERC-2981 (`royaltyInfo(tokenId, salePrice)`). The royalty receiver is the stored `creator` address (not the current owner). This preserves the fine-tuner's economic interest across resales.
+
+Resale markets MUST forward royalties per ERC-2981 for the spec to hold — enforcement is out of scope.
+
+### 3.7 Attestation hook integration
+
+Implementations SHOULD register verifiable-training attestations via the existing `ERC721AIAttestationHook` contract in this repo. When an attestation is registered for a token, the `attestationKind` field SHOULD be updated on the model asset record to reflect the kind of attestation present (e.g., `keccak256("ZK_PROOF")`, `keccak256("TEE_SIG")`).
+
+### 3.8 Security considerations
+
+1. **Weights tampering.** The `artifactHash` locks the token to specific weights. Any mutation of the weights bundle breaks the hash commitment. Indexers SHOULD re-verify the hash before trusting weights fetched from `weightsCID`.
+2. **Endpoint mutability.** `inferenceEndpoint` is mutable by the token owner. A malicious seller could flip the endpoint to a degraded model between sale and first buyer use. Buyers should re-verify the endpoint serves weights hashing to `artifactHash` (via the standard "echo model hash" ping defined in §3.9).
+3. **Royalty evasion.** ERC-2981 is advisory; marketplaces MAY ignore it. Creators should not treat the royalty as a guaranteed cash stream.
+4. **Provenance-chain spoofing.** A malicious minter could declare an arbitrary `baseModel` to inflate lineage claims. Attestations (§3.7) are the cryptographic counter — a `ZK_PROOF` attestation ties weights to a specific training job.
+
+### 3.9 Echo-model-hash endpoint convention (optional)
+
+For endpoints that expose inference over HTTP, the standard hints at a convention: an `OPTIONS /model-hash` (or equivalent) response that returns the `artifactHash` and a short signature over the server's timestamp. Defining the wire format is out of scope for v0 — left to a companion draft.
+
+## 4. Backwards compatibility
+
+ERC-721 AI is additive. An ERC-721 AI contract IS an ERC-721 contract, so existing wallets, marketplaces, and indexers continue to render model-asset tokens as ordinary NFTs. Only ERC-721-AI-aware tooling reads the `model` object.
+
+## 5. Reference implementation
+
+See `contracts/ERC721AI.sol` in this repo for a minimal reference. Tests in `test/ERC721AI.t.sol` cover mint / transfer / royalty / endpoint-update / provenance-chain lookup.
+
+## 6. Open questions (v0 → v1)
+
+- Should weights be referenced by CID or by a pair `(registry, repoId)` (so HuggingFace-style references are first-class)?
+- Should multiple royalty recipients be supported (data curator + fine-tuner + infra provider split)? ERC-2981 is single-recipient; `ERC-2981 extensions` exist as proposals but none are standard yet.
+- Soulbound models — should a model asset be non-transferable by default while training is in progress (ERC-5192 integration)?
+- Cross-contract provenance chains.
+- Echo-model-hash endpoint wire format.
+
+These are deferred to a v1 draft once v0 is in production use.

--- a/test/ERC721AI.t.sol
+++ b/test/ERC721AI.t.sol
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/ERC721AI.sol";
+
+contract ERC721AITest is Test {
+    ERC721AI internal erc721ai;
+
+    address internal creator;
+    address internal alice;
+    address internal bob;
+
+    bytes32 internal constant MODEL_ID_A = keccak256("model-a");
+    bytes32 internal constant ARTIFACT_HASH_A = keccak256("weights-a");
+    bytes32 internal constant MODEL_ID_B = keccak256("model-b");
+    bytes32 internal constant ARTIFACT_HASH_B = keccak256("weights-b");
+
+    function setUp() public {
+        creator = makeAddr("creator");
+        alice = makeAddr("alice");
+        bob = makeAddr("bob");
+
+        erc721ai = new ERC721AI("ERC-721 AI", "AI721");
+    }
+
+    // ── Deployment ──────────────────────────────────────────────────────
+
+    function test_NameAndSymbol() public view {
+        assertEq(erc721ai.name(), "ERC-721 AI");
+        assertEq(erc721ai.symbol(), "AI721");
+    }
+
+    function test_SupportsInterface() public view {
+        assertTrue(erc721ai.supportsInterface(0x01ffc9a7)); // ERC-165
+        assertTrue(erc721ai.supportsInterface(0x80ac58cd)); // ERC-721
+        assertTrue(erc721ai.supportsInterface(0x5b5e139f)); // ERC-721 Metadata
+        assertTrue(erc721ai.supportsInterface(0x2a55205a)); // ERC-2981
+        assertFalse(erc721ai.supportsInterface(0xdeadbeef));
+    }
+
+    // ── Mint ────────────────────────────────────────────────────────────
+
+    function test_MintsModelAsset() public {
+        vm.prank(creator);
+        uint256 tokenId = erc721ai.mintModel(
+            alice,
+            MODEL_ID_A,
+            ARTIFACT_HASH_A,
+            bytes32(0),
+            "ipfs://weights-a",
+            "llama-3.1-70b-instruct",
+            "LLAMA3-COMMUNITY",
+            "https://inf.example/m/a",
+            500
+        );
+
+        assertEq(tokenId, 1);
+        assertEq(erc721ai.ownerOf(1), alice);
+        assertEq(erc721ai.balanceOf(alice), 1);
+        assertEq(erc721ai.totalSupply(), 1);
+        assertEq(erc721ai.tokenIdByModelId(MODEL_ID_A), 1);
+
+        (
+            bytes32 modelId,
+            bytes32 artifactHash,
+            bytes32 baseModel,
+            string memory weightsCID,
+            string memory architecture,
+            string memory license,
+            string memory inferenceEndpoint,
+            uint16 creatorRoyaltyBps,
+            uint64 createdAt,
+            address creatorAddr
+        ) = erc721ai.modelAsset(1);
+
+        assertEq(modelId, MODEL_ID_A);
+        assertEq(artifactHash, ARTIFACT_HASH_A);
+        assertEq(baseModel, bytes32(0));
+        assertEq(weightsCID, "ipfs://weights-a");
+        assertEq(architecture, "llama-3.1-70b-instruct");
+        assertEq(license, "LLAMA3-COMMUNITY");
+        assertEq(inferenceEndpoint, "https://inf.example/m/a");
+        assertEq(creatorRoyaltyBps, 500);
+        assertGt(createdAt, 0);
+        assertEq(creatorAddr, creator);
+    }
+
+    function test_RevertWhenMintToZero() public {
+        vm.prank(creator);
+        vm.expectRevert(ERC721AI.InvalidRecipient.selector);
+        erc721ai.mintModel(address(0), MODEL_ID_A, ARTIFACT_HASH_A, bytes32(0), "", "", "", "", 0);
+    }
+
+    function test_RevertWhenZeroModelId() public {
+        vm.prank(creator);
+        vm.expectRevert(ERC721AI.ZeroModelId.selector);
+        erc721ai.mintModel(alice, bytes32(0), ARTIFACT_HASH_A, bytes32(0), "", "", "", "", 0);
+    }
+
+    function test_RevertWhenZeroArtifactHash() public {
+        vm.prank(creator);
+        vm.expectRevert(ERC721AI.ZeroArtifactHash.selector);
+        erc721ai.mintModel(alice, MODEL_ID_A, bytes32(0), bytes32(0), "", "", "", "", 0);
+    }
+
+    function test_RevertWhenDuplicateModelId() public {
+        vm.startPrank(creator);
+        erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_A, bytes32(0), "", "", "", "", 0);
+        vm.expectRevert(ERC721AI.ModelIdAlreadyMinted.selector);
+        erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_B, bytes32(0), "", "", "", "", 0);
+        vm.stopPrank();
+    }
+
+    function test_RevertWhenRoyaltyTooHigh() public {
+        vm.prank(creator);
+        vm.expectRevert(ERC721AI.RoyaltyTooHigh.selector);
+        erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_A, bytes32(0), "", "", "", "", 10_001);
+    }
+
+    function test_RevertWhenBaseModelNotFound() public {
+        bytes32 ghost = keccak256("ghost-base-model");
+        vm.prank(creator);
+        vm.expectRevert(ERC721AI.BaseModelNotFound.selector);
+        erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_A, ghost, "", "", "", "", 0);
+    }
+
+    // ── Provenance chain ────────────────────────────────────────────────
+
+    function test_ProvenanceChainTwoHops() public {
+        vm.startPrank(creator);
+        uint256 tokenA = erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_A, bytes32(0), "", "llama-3.1-70b", "MIT", "", 0);
+        uint256 tokenB = erc721ai.mintModel(alice, MODEL_ID_B, ARTIFACT_HASH_B, MODEL_ID_A, "", "llama-3.1-70b-ft", "MIT", "", 0);
+        vm.stopPrank();
+
+        (,, bytes32 baseB,,,,,,,) = erc721ai.modelAsset(tokenB);
+        assertEq(baseB, MODEL_ID_A);
+        assertEq(erc721ai.tokenIdByModelId(baseB), tokenA);
+    }
+
+    // ── Royalties ───────────────────────────────────────────────────────
+
+    function test_RoyaltyInfo() public {
+        vm.prank(creator);
+        uint256 tokenId = erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_A, bytes32(0), "", "", "", "", 750);
+
+        (address receiver, uint256 amount) = erc721ai.royaltyInfo(tokenId, 1 ether);
+        assertEq(receiver, creator);
+        assertEq(amount, (1 ether * 750) / 10_000);
+    }
+
+    function test_RoyaltyGoesToCreatorNotCurrentOwner() public {
+        vm.prank(creator);
+        uint256 tokenId = erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_A, bytes32(0), "", "", "", "", 500);
+
+        // Alice transfers to Bob.
+        vm.prank(alice);
+        erc721ai.transferFrom(alice, bob, tokenId);
+
+        (address receiver,) = erc721ai.royaltyInfo(tokenId, 1 ether);
+        assertEq(receiver, creator); // still creator, not Bob.
+    }
+
+    // ── Endpoint mutation ───────────────────────────────────────────────
+
+    function test_OwnerCanUpdateInferenceEndpoint() public {
+        vm.prank(creator);
+        uint256 tokenId = erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_A, bytes32(0), "", "", "", "https://old", 0);
+
+        vm.prank(alice);
+        erc721ai.setInferenceEndpoint(tokenId, "https://new");
+
+        (,,,,,, string memory endpoint,,,) = erc721ai.modelAsset(tokenId);
+        assertEq(endpoint, "https://new");
+    }
+
+    function test_RevertWhenNonOwnerUpdatesEndpoint() public {
+        vm.prank(creator);
+        uint256 tokenId = erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_A, bytes32(0), "", "", "", "", 0);
+
+        vm.prank(bob);
+        vm.expectRevert(ERC721AI.NotTokenOwner.selector);
+        erc721ai.setInferenceEndpoint(tokenId, "https://evil");
+    }
+
+    // ── Attestation kind mutation ───────────────────────────────────────
+
+    function test_CreatorCanSetAttestationKind() public {
+        vm.prank(creator);
+        uint256 tokenId = erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_A, bytes32(0), "", "", "", "", 0);
+
+        bytes32 kind = keccak256("ZK_PROOF");
+        vm.expectEmit(true, false, false, true);
+        emit ERC721AI.AttestationKindUpdated(tokenId, kind);
+
+        vm.prank(creator);
+        erc721ai.setAttestationKind(tokenId, kind);
+    }
+
+    function test_RevertWhenNonCreatorSetsAttestation() public {
+        vm.prank(creator);
+        uint256 tokenId = erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_A, bytes32(0), "", "", "", "", 0);
+
+        vm.prank(alice); // owner, but not creator
+        vm.expectRevert(ERC721AI.NotOwnerOrApproved.selector);
+        erc721ai.setAttestationKind(tokenId, keccak256("ZK_PROOF"));
+    }
+
+    // ── Transfer semantics ──────────────────────────────────────────────
+
+    function test_TransferFromUpdatesOwner() public {
+        vm.prank(creator);
+        uint256 tokenId = erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_A, bytes32(0), "", "", "", "", 0);
+
+        vm.prank(alice);
+        erc721ai.transferFrom(alice, bob, tokenId);
+
+        assertEq(erc721ai.ownerOf(tokenId), bob);
+        assertEq(erc721ai.balanceOf(alice), 0);
+        assertEq(erc721ai.balanceOf(bob), 1);
+    }
+
+    function test_RevertWhenUnauthorizedTransfer() public {
+        vm.prank(creator);
+        uint256 tokenId = erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_A, bytes32(0), "", "", "", "", 0);
+
+        vm.prank(bob);
+        vm.expectRevert(ERC721AI.NotOwnerOrApproved.selector);
+        erc721ai.transferFrom(alice, bob, tokenId);
+    }
+
+    function test_ApprovedAddressCanTransfer() public {
+        vm.prank(creator);
+        uint256 tokenId = erc721ai.mintModel(alice, MODEL_ID_A, ARTIFACT_HASH_A, bytes32(0), "", "", "", "", 0);
+
+        vm.prank(alice);
+        erc721ai.approve(bob, tokenId);
+
+        vm.prank(bob);
+        erc721ai.transferFrom(alice, bob, tokenId);
+
+        assertEq(erc721ai.ownerOf(tokenId), bob);
+    }
+}


### PR DESCRIPTION
## Summary

Lands the two foundational issues for this repo in one PR:

- **#2** — Draft ERC-721 AI token standard specification (`docs/spec-erc721-ai.md`).
- **#1** — Reference Solidity implementation (`contracts/ERC721AI.sol`) + Foundry tests (`test/ERC721AI.t.sol`).

## What's in the spec (`docs/spec-erc721-ai.md`)

- Abstract + motivation (ownership / provenance / access gaps the standard fills).
- Metadata schema: `modelId`, `weightsCID`, `artifactHash`, `baseModel`, `architecture`, `license`, `inferenceEndpoint`, `attestationKind`, `creatorRoyaltyBps`, `createdAt`, `creator`.
- On-chain struct layout + `tokenURI` JSON schema.
- Required interface (`mintModel`, `modelAsset`, `setInferenceEndpoint`).
- Provenance-chain semantics (same-contract v0, cross-contract deferred to v1).
- ERC-2981 royalty semantics — receiver is the creator, persists past transfers.
- Integration with the existing attestation-hook extension (ZK / TEE).
- Security considerations: weights tampering, endpoint mutability, royalty evasion, provenance spoofing.
- Open questions deferred to v1 (multi-recipient royalties, soulbound-in-training, cross-contract provenance, echo-model-hash wire format).

## What's in the reference contract (`contracts/ERC721AI.sol`)

Dependency-free minimal implementation:

- `mintModel(...)` with full validation (zero-model-id, zero-artifact-hash, duplicate-model-id, royalty-bps cap, base-model existence).
- `modelAsset(tokenId)` getter returning the full asset record.
- `setInferenceEndpoint(tokenId, endpoint)` — only current owner.
- `setAttestationKind(tokenId, kind)` — only original creator (couples with the attestation-hook's verification).
- `royaltyInfo(tokenId, salePrice)` per ERC-2981, receiver is the immutable `creator` field.
- `tokenIdByModelId` reverse index for provenance-chain traversal.
- ERC-165 reporting for ERC-165 / ERC-721 / ERC-721 Metadata / ERC-2981.
- Inline minimal ERC-721 (balanceOf / ownerOf / approve / getApproved / setApprovalForAll / isApprovedForAll / transferFrom / safeTransferFrom) — production deployments SHOULD inherit an audited base (OpenZeppelin). This reference trades bytecode size for readability and testability.

## What's in the tests (`test/ERC721AI.t.sol`)

- Deployment: name, symbol, `supportsInterface` for all declared interfaces.
- Mint happy path: verifies every field of the stored `ModelAsset`.
- Mint revert paths: invalid recipient, zero model id, zero artifact hash, duplicate model id, royalty > 10000 bps, base model not found.
- Provenance chain: two-hop parent-child, `tokenIdByModelId` lookup.
- Royalty: correct amount, receiver stays creator after owner transfer.
- Endpoint mutation: owner updates succeed, non-owner reverts.
- Attestation kind mutation: creator updates succeed (with event), non-creator reverts.
- Transfer semantics: direct transfer, unauthorized reverts, approved-address transfer.

## Not in scope (deferred to follow-up PRs)

- ERC721Receiver hook in `safeTransferFrom` (intentionally omitted from the minimal reference; noted in a code comment).
- ERC-4906 metadata-update events.
- Enumerable extension.
- OpenZeppelin-based production variant (separate PR, tracked by the "production deployments" callout in the spec).
- `#11` Giza ZKML integration (depends on this spec landing).
- `#9` x402 per-inference metering (depends on this spec landing).
- `#3` EIP-2981 royalty support — **already included in this PR** (note: issue #3 may be closable by this merge).

## Build / test notes

Foundry is not available in the CI environment this PR was drafted in; tests were not executed locally before the push. Reviewer should run `forge install foundry-rs/forge-std --no-commit` then `forge test` to verify the full suite green. If anything fails I'll push a fixup immediately.

## Test plan

- [ ] `forge install foundry-rs/forge-std --no-commit`
- [ ] `forge build`
- [ ] `forge test -vvv` — expect all ERC721AI tests green, plus existing ERC721AIAttestationHook tests unchanged.
- [ ] Review the spec doc for any metadata fields to add / rename before external circulation.
- [ ] Close #3 if reviewer agrees the in-built ERC-2981 support is sufficient; otherwise leave it open with a scoped follow-up.

Closes #1.
Closes #2.