### PR TITLE
feat(sdk): TypeScript SDK for model / metering / attestation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 cache/
 out/
 broadcast/
+sdk/typescript/dist/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ This repo also includes a pluggable contract-level attestation hook for verifiab
 
 Design and integration details are documented in `docs/attestation-hook.md`.
 
+## TypeScript SDK
+
+A viem-based TypeScript SDK for the standard lives in [`sdk/typescript/`](./sdk/typescript/) — it wraps `ERC721AI`, `ERC721AIx402Metering`, and `ERC721AIAttestationHook` behind three modules (`model`, `metering`, `attestation`) so consumers can mint a tokenised model, set an inference price, pay per call, and withdraw revenue in roughly five lines of code. See [`sdk/typescript/README.md`](./sdk/typescript/README.md) for the quickstart.
+
 ## Links
 
 - **Docs:** https://docs.kcolbchain.com/erc721-ai/

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,0 +1,171 @@
+# @kcolbchain/erc721-ai-sdk
+
+TypeScript SDK for the [erc721-ai](https://github.com/kcolbchain/erc721-ai)
+standard — tokenised fine-tuned AI model weights with ERC-2981 royalties,
+x402-style per-inference USDC metering, and a pluggable training
+attestation hook.
+
+The SDK is a thin [viem](https://viem.sh)-based wrapper: reads go through
+`publicClient`, writes through `walletClient`, and the full surface is
+usable in about five lines of code.
+
+## Install
+
+```bash
+npm install @kcolbchain/erc721-ai-sdk viem
+```
+
+Requires Node 18+. Exports are dual ESM + CJS with `.d.ts` shipped.
+
+## Quickstart
+
+```ts
+import { createPublicClient, createWalletClient, http } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { createErc721AiClient } from '@kcolbchain/erc721-ai-sdk';
+
+const publicClient = createPublicClient({ transport: http(process.env.RPC_URL!) });
+const walletClient = createWalletClient({
+  account: privateKeyToAccount(process.env.PK as `0x${string}`),
+  transport: http(process.env.RPC_URL!),
+});
+
+const ai = createErc721AiClient({
+  contracts: {
+    erc721ai: '0x...',   // ERC721AI model-asset NFT
+    metering: '0x...',   // ERC721AIx402Metering (USDC per-inference)
+    attestation: '0x...' // optional — ERC721AIAttestationHook
+  },
+  publicClient,
+  walletClient,
+});
+```
+
+From here you have three modules:
+
+### `ai.model` — `ModelModule`
+
+Wraps `ERC721AI.sol`. Reads: `ownerOf`, `tokenURI`, `modelAsset`,
+`royaltyInfo`, `tokenIdByModelId`, `totalSupply`. Writes: `mintModel`,
+`setInferenceEndpoint`, `setAttestationKind`.
+
+```ts
+const { hash, wait } = await ai.model.mintModel({
+  to: '0x...',
+  modelId: '0x...',         // bytes32 — unique per model
+  artifactHash: '0x...',    // bytes32 — weights blob hash
+  baseModel: '0x00...',     // bytes32 — 0x0 for root models
+  weightsCID: 'bafy...',
+  architecture: 'llama-7b',
+  license: 'Apache-2.0',
+  inferenceEndpoint: 'https://infer.example.com/v1/completions',
+  creatorRoyaltyBps: 500,   // 5%
+});
+await wait();
+```
+
+`tokenURI(tokenId)` is synthesised client-side from the on-chain
+`weightsCID` as `ipfs://<cid>` (the reference contract does not store a
+separate metadata URI).
+
+### `ai.metering` — `MeteringModule`
+
+Wraps `ERC721AIx402Metering.sol`. Reads: `getInferencePrice`,
+`getModelInfo`, `totalInferences`, `revenueBalance`, `usdc`,
+`protocolFeeBps`. Writes: `registerModel`, `setInferencePrice`,
+`payForInference`, `payForInferences`, `setModelActive`,
+`withdrawRevenue`.
+
+Prices are `uint128` atomic units of USDC (6 decimals — `100_000n` is
+$0.10).
+
+```ts
+await (await ai.metering.registerModel({ tokenId: 1n, pricePerInference: 100_000n })).wait();
+await (await ai.metering.setInferencePrice({ tokenId: 1n, newPrice: 50_000n })).wait();
+const price = await ai.metering.getInferencePrice(1n);
+await (await ai.metering.payForInference(1n)).wait(); // consumer flow
+await (await ai.metering.withdrawRevenue()).wait();   // owner flow
+```
+
+### `ai.attestation` — `AttestationModule` *(optional)*
+
+Wraps `ERC721AIAttestationHook.sol`. Only accessible when
+`contracts.attestation` is configured — otherwise reading `ai.attestation`
+throws `MissingAttestationError`.
+
+```ts
+await (await ai.attestation.registerAttestation({
+  tokenId: 1n,
+  modelId: '0x...',
+  artifactHash: '0x...',
+  attestationKind: '0x...',    // e.g. keccak256("tee:intel-sgx")
+  attestationData: '0x...',    // passed to the configured verifier
+})).wait();
+
+const ok = await ai.attestation.verifyAttestation({
+  tokenId: 1n,
+  modelId: '0x...',
+  artifactHash: '0x...',
+  attestationKind: '0x...',
+});
+```
+
+`verifyAttestation` does a lightweight on-chain record comparison; it does
+not re-run the cryptographic verifier. For re-verification, invoke the
+underlying proof system off-chain with the original `attestationData`.
+
+## x402 integration
+
+The metering contract is designed to sit behind an HTTP 402 gate: an
+inference server receives a request, responds with `402 Payment Required`
+and a price, the consumer calls `ai.metering.payForInference(tokenId)` to
+produce an on-chain `InferencePaid` event, and the server watches for that
+event before serving the inference.
+
+This SDK does not bundle the HTTP side — it only provides the on-chain
+rails. A minimal consumer pseudocode:
+
+```ts
+// Server responds 402 with { tokenId, price, meteringAddress }.
+const { tokenId, price } = JSON.parse(res.headers.get('x402-challenge')!);
+
+// 1. Approve USDC once (or for the required amount).
+await usdc.approve(meteringAddress, price);
+
+// 2. Pay.
+const { hash, wait } = await ai.metering.payForInference(BigInt(tokenId));
+await wait();
+
+// 3. Retry the request with the tx hash as proof.
+await fetch(inferenceUrl, { headers: { 'x402-payment': hash } });
+```
+
+## Errors
+
+All SDK errors extend `Erc721AiSdkError`:
+
+- `MissingWalletError` — a write method was called without a
+  `walletClient`.
+- `InvalidPriceError` — `setInferencePrice` / `registerModel` was given a
+  non-positive or out-of-uint128 price.
+- `ModelNotFoundError` — `getModelInfo` returned the zero owner, i.e. the
+  tokenId has never been registered for metering.
+- `MissingAttestationError` — `ai.attestation` was accessed without
+  `contracts.attestation`.
+
+## Development
+
+```bash
+cd sdk/typescript
+npm install
+npm run typecheck
+npm test
+npm run build       # emits dist/index.mjs + dist/index.cjs + dist/*.d.ts
+```
+
+Tests use an in-memory EIP-1193 mock transport — no live chain is
+required. See `test/helpers.ts`.
+
+## License
+
+MIT

--- a/sdk/typescript/examples/mint-and-meter.ts
+++ b/sdk/typescript/examples/mint-and-meter.ts
@@ -1,0 +1,106 @@
+/**
+ * End-to-end example: mint a model, set an inference price, simulate a
+ * consumer paying for one inference, and withdraw the accumulated revenue.
+ *
+ * This file is written as a runnable script but will not work against a
+ * real chain without valid RPC + funded key + deployed contracts; it is
+ * primarily a README-level walkthrough of the SDK surface.
+ *
+ *   npx tsx examples/mint-and-meter.ts
+ */
+
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  keccak256,
+  stringToBytes,
+  type Address,
+  type Hex,
+} from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { createErc721AiClient, Erc20Abi } from '../src/index.js';
+
+async function main() {
+  const rpcUrl = process.env.RPC_URL ?? 'http://127.0.0.1:8545';
+  const pk = (process.env.PK ?? '0x' + '11'.repeat(32)) as Hex;
+
+  const erc721aiAddress = (process.env.ERC721AI_ADDRESS ??
+    '0x0000000000000000000000000000000000000001') as Address;
+  const meteringAddress = (process.env.METERING_ADDRESS ??
+    '0x0000000000000000000000000000000000000002') as Address;
+  const usdcAddress = (process.env.USDC_ADDRESS ??
+    '0x0000000000000000000000000000000000000003') as Address;
+
+  const account = privateKeyToAccount(pk);
+  const publicClient = createPublicClient({ transport: http(rpcUrl) });
+  const walletClient = createWalletClient({
+    account,
+    transport: http(rpcUrl),
+  });
+
+  // --- 5-line quickstart ----------------------------------------------
+  const ai = createErc721AiClient({
+    contracts: { erc721ai: erc721aiAddress, metering: meteringAddress },
+    publicClient,
+    walletClient,
+  });
+  // --------------------------------------------------------------------
+
+  // 1. Mint the tokenised model.
+  const modelId = keccak256(stringToBytes('example-llama-7b-finetune-v1'));
+  const artifactHash = keccak256(stringToBytes('weights-blob-sha256-...'));
+  const baseModel = ('0x' + '00'.repeat(32)) as Hex; // root model
+
+  const mint = await ai.model.mintModel({
+    to: account.address,
+    modelId,
+    artifactHash,
+    baseModel,
+    weightsCID: 'bafybeigweightsCIDplaceholder',
+    architecture: 'llama-7b',
+    license: 'Apache-2.0',
+    inferenceEndpoint: 'https://infer.example.com/v1/completions',
+    creatorRoyaltyBps: 500,
+  });
+  await mint.wait();
+  console.log('minted; tx:', mint.hash);
+
+  // Find the token id the reference contract just assigned.
+  const tokenId = await ai.model.tokenIdByModelId(modelId);
+  console.log('tokenId:', tokenId.toString());
+
+  // 2. Register the model with the metering contract and set the price.
+  const price = 100_000n; // 0.10 USDC (6-decimal atomic units)
+  await (await ai.metering.registerModel({ tokenId, pricePerInference: price })).wait();
+  console.log('metering registered at price (USDC atomic):', price.toString());
+
+  // 3. Consumer path: approve USDC, then pay. Here we reuse the same
+  //    wallet for brevity; a real consumer would be a different account.
+  const approveTx = await walletClient.writeContract({
+    address: usdcAddress,
+    abi: Erc20Abi,
+    functionName: 'approve',
+    args: [meteringAddress, price],
+    account,
+    chain: null,
+  });
+  await publicClient.waitForTransactionReceipt({ hash: approveTx });
+
+  const pay = await ai.metering.payForInference(tokenId);
+  await pay.wait();
+  console.log('paid for one inference; tx:', pay.hash);
+
+  // 4. Model owner withdraws the accumulated revenue.
+  const bal = await ai.metering.revenueBalance(account.address);
+  console.log('pending revenue (USDC atomic):', bal.toString());
+  const wdr = await ai.metering.withdrawRevenue();
+  await wdr.wait();
+  console.log('withdrew; tx:', wdr.hash);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,0 +1,2583 @@
+{
+  "name": "@kcolbchain/erc721-ai-sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@kcolbchain/erc721-ai-sdk",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "viem": "^2.21.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "tsx": "^4.16.0",
+        "typescript": "^5.5.0",
+        "vitest": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.14.20",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.20.tgz",
+      "integrity": "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/viem": {
+      "version": "2.48.4",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.4.tgz",
+      "integrity": "sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.20",
+        "ws": "8.18.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@kcolbchain/erc721-ai-sdk",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for the ERC-721 AI standard (ERC721AI, x402 per-inference metering, attestation hook).",
+  "license": "MIT",
+  "author": "kcolbchain",
+  "homepage": "https://github.com/kcolbchain/erc721-ai",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kcolbchain/erc721-ai.git",
+    "directory": "sdk/typescript"
+  },
+  "keywords": [
+    "erc721-ai",
+    "ai",
+    "model-weights",
+    "ERC-721",
+    "ERC-2981",
+    "x402",
+    "metering",
+    "attestation",
+    "viem",
+    "kcolbchain"
+  ],
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && node scripts/build-dual.mjs",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "example:mint-and-meter": "tsx examples/mint-and-meter.ts"
+  },
+  "dependencies": {
+    "viem": "^2.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "tsx": "^4.16.0",
+    "typescript": "^5.5.0",
+    "vitest": "^1.6.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/sdk/typescript/scripts/build-dual.mjs
+++ b/sdk/typescript/scripts/build-dual.mjs
@@ -1,0 +1,98 @@
+// Minimal post-processing to produce dual ESM+CJS outputs from the tsc
+// build. We rely on the fact that the source is written as pure ESM with
+// `.js` extension imports; tsc emits those as ESM into dist/. We then:
+//   1. rename dist/index.js -> dist/index.mjs (and rewrite its own .js
+//      imports to .mjs)
+//   2. emit a small dist/index.cjs shim that re-exports from the ESM via
+//      dynamic import, so require() works for consumers that need CJS.
+//
+// This is intentionally lightweight — no bundler, no extra deps.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dist = path.resolve(__dirname, '..', 'dist');
+
+async function exists(p) {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function listJsFiles(dir) {
+  const out = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      out.push(...(await listJsFiles(full)));
+    } else if (e.isFile() && e.name.endsWith('.js')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+async function main() {
+  if (!(await exists(dist))) {
+    console.error(`dist/ not found at ${dist}; run tsc first.`);
+    process.exit(1);
+  }
+
+  const jsFiles = await listJsFiles(dist);
+
+  // 1) Rename each .js -> .mjs and rewrite internal imports from ".js" to ".mjs".
+  for (const file of jsFiles) {
+    const contents = await fs.readFile(file, 'utf8');
+    // Rewrite relative-import extensions: from './x.js' -> from './x.mjs'
+    const rewritten = contents
+      .replace(/from\s+['"](\.\/[^'"\n]+)\.js['"]/g, "from '$1.mjs'")
+      .replace(/from\s+['"](\.\.\/[^'"\n]+)\.js['"]/g, "from '$1.mjs'")
+      .replace(/import\s*\(\s*['"](\.\/[^'"\n]+)\.js['"]\s*\)/g, "import('$1.mjs')")
+      .replace(/import\s*\(\s*['"](\.\.\/[^'"\n]+)\.js['"]\s*\)/g, "import('$1.mjs')");
+    const newPath = file.replace(/\.js$/, '.mjs');
+    await fs.writeFile(newPath, rewritten, 'utf8');
+    await fs.unlink(file);
+    // Keep the source map file pointing at the new extension.
+    const mapPath = file + '.map';
+    if (await exists(mapPath)) {
+      const mapSrc = await fs.readFile(mapPath, 'utf8');
+      try {
+        const map = JSON.parse(mapSrc);
+        if (typeof map.file === 'string' && map.file.endsWith('.js')) {
+          map.file = map.file.replace(/\.js$/, '.mjs');
+        }
+        await fs.writeFile(newPath + '.map', JSON.stringify(map), 'utf8');
+        await fs.unlink(mapPath);
+      } catch {
+        // Best-effort — if the map isn't JSON just move it verbatim.
+        await fs.writeFile(newPath + '.map', mapSrc, 'utf8');
+        await fs.unlink(mapPath);
+      }
+    }
+  }
+
+  // 2) Emit a CJS shim at dist/index.cjs that lazily delegates to the ESM.
+  const shim = `"use strict";
+// Auto-generated CJS shim. Delegates to dist/index.mjs.
+// Consumers using require() get a Promise-wrapped module; consumers that
+// need synchronous interop should import the ESM entry directly.
+module.exports = (async () => {
+  return await import('./index.mjs');
+})();
+module.exports.default = module.exports;
+`;
+  await fs.writeFile(path.join(dist, 'index.cjs'), shim, 'utf8');
+
+  console.log('dual-build post-processing complete');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/sdk/typescript/src/abis.ts
+++ b/sdk/typescript/src/abis.ts
@@ -1,0 +1,336 @@
+/**
+ * Minimal ABIs for the erc721-ai core contracts.
+ *
+ * Hand-curated to cover the public surface the SDK exposes. Regenerate /
+ * extend by compiling the Solidity sources under `contracts/` with Foundry
+ * if you need the full interface.
+ */
+
+export const Erc721AiAbi = [
+  // ─── Views ──────────────────────────────────────────────────────────
+  {
+    type: 'function',
+    name: 'ownerOf',
+    stateMutability: 'view',
+    inputs: [{ name: 'tokenId', type: 'uint256' }],
+    outputs: [{ name: '', type: 'address' }],
+  },
+  {
+    type: 'function',
+    name: 'balanceOf',
+    stateMutability: 'view',
+    inputs: [{ name: 'owner', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'totalSupply',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'tokenIdByModelId',
+    stateMutability: 'view',
+    inputs: [{ name: 'modelId', type: 'bytes32' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'modelAsset',
+    stateMutability: 'view',
+    inputs: [{ name: 'tokenId', type: 'uint256' }],
+    outputs: [
+      { name: 'modelId', type: 'bytes32' },
+      { name: 'artifactHash', type: 'bytes32' },
+      { name: 'baseModel', type: 'bytes32' },
+      { name: 'weightsCID', type: 'string' },
+      { name: 'architecture', type: 'string' },
+      { name: 'license', type: 'string' },
+      { name: 'inferenceEndpoint', type: 'string' },
+      { name: 'creatorRoyaltyBps', type: 'uint16' },
+      { name: 'createdAt', type: 'uint64' },
+      { name: 'creator', type: 'address' },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'royaltyInfo',
+    stateMutability: 'view',
+    inputs: [
+      { name: 'tokenId', type: 'uint256' },
+      { name: 'salePrice', type: 'uint256' },
+    ],
+    outputs: [
+      { name: 'receiver', type: 'address' },
+      { name: 'royaltyAmount', type: 'uint256' },
+    ],
+  },
+  // The reference contract does not expose a canonical `tokenURI`. We
+  // synthesise one client-side from `weightsCID` when callers ask for it —
+  // see ModelModule.tokenURI — so no ABI entry is required here.
+  // ─── Writes ─────────────────────────────────────────────────────────
+  {
+    type: 'function',
+    name: 'mintModel',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'to', type: 'address' },
+      { name: 'modelId', type: 'bytes32' },
+      { name: 'artifactHash', type: 'bytes32' },
+      { name: 'baseModel', type: 'bytes32' },
+      { name: 'weightsCID', type: 'string' },
+      { name: 'architecture', type: 'string' },
+      { name: 'license', type: 'string' },
+      { name: 'inferenceEndpoint', type: 'string' },
+      { name: 'creatorRoyaltyBps', type: 'uint16' },
+    ],
+    outputs: [{ name: 'tokenId', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'setInferenceEndpoint',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'tokenId', type: 'uint256' },
+      { name: 'endpoint', type: 'string' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'setAttestationKind',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'tokenId', type: 'uint256' },
+      { name: 'kind', type: 'bytes32' },
+    ],
+    outputs: [],
+  },
+  // ─── Events ─────────────────────────────────────────────────────────
+  {
+    type: 'event',
+    name: 'ModelMinted',
+    inputs: [
+      { name: 'tokenId', type: 'uint256', indexed: true },
+      { name: 'modelId', type: 'bytes32', indexed: true },
+      { name: 'artifactHash', type: 'bytes32', indexed: true },
+      { name: 'creator', type: 'address', indexed: false },
+      { name: 'weightsCID', type: 'string', indexed: false },
+    ],
+    anonymous: false,
+  },
+] as const;
+
+export const Erc721AiMeteringAbi = [
+  // ─── Views ──────────────────────────────────────────────────────────
+  {
+    type: 'function',
+    name: 'usdc',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'address' }],
+  },
+  {
+    type: 'function',
+    name: 'admin',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'address' }],
+  },
+  {
+    type: 'function',
+    name: 'protocolFeeBps',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint16' }],
+  },
+  {
+    type: 'function',
+    name: 'getInferencePrice',
+    stateMutability: 'view',
+    inputs: [{ name: 'tokenId', type: 'uint256' }],
+    outputs: [{ name: '', type: 'uint128' }],
+  },
+  {
+    type: 'function',
+    name: 'getModelInfo',
+    stateMutability: 'view',
+    inputs: [{ name: 'tokenId', type: 'uint256' }],
+    outputs: [
+      { name: 'owner', type: 'address' },
+      { name: 'price', type: 'uint128' },
+      { name: 'active', type: 'bool' },
+      { name: 'inferences', type: 'uint256' },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'totalInferences',
+    stateMutability: 'view',
+    inputs: [{ name: 'tokenId', type: 'uint256' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'revenueBalance',
+    stateMutability: 'view',
+    inputs: [{ name: 'owner', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  // ─── Writes ─────────────────────────────────────────────────────────
+  {
+    type: 'function',
+    name: 'registerModel',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'tokenId', type: 'uint256' },
+      { name: 'pricePerInference', type: 'uint128' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'setInferencePrice',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'tokenId', type: 'uint256' },
+      { name: 'newPrice', type: 'uint128' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'setModelActive',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'tokenId', type: 'uint256' },
+      { name: 'active', type: 'bool' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'payForInference',
+    stateMutability: 'nonpayable',
+    inputs: [{ name: 'tokenId', type: 'uint256' }],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'payForInferences',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'tokenId', type: 'uint256' },
+      { name: 'count', type: 'uint256' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'withdrawRevenue',
+    stateMutability: 'nonpayable',
+    inputs: [],
+    outputs: [],
+  },
+  // ─── Events ─────────────────────────────────────────────────────────
+  {
+    type: 'event',
+    name: 'InferencePaid',
+    inputs: [
+      { name: 'tokenId', type: 'uint256', indexed: true },
+      { name: 'caller', type: 'address', indexed: true },
+      { name: 'amount', type: 'uint128', indexed: false },
+      { name: 'inferenceCount', type: 'uint256', indexed: false },
+    ],
+    anonymous: false,
+  },
+] as const;
+
+export const Erc721AiAttestationHookAbi = [
+  // ─── Views ──────────────────────────────────────────────────────────
+  {
+    type: 'function',
+    name: 'owner',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'address' }],
+  },
+  {
+    type: 'function',
+    name: 'attestationVerifiers',
+    stateMutability: 'view',
+    inputs: [{ name: 'attestationKind', type: 'bytes32' }],
+    outputs: [{ name: '', type: 'address' }],
+  },
+  {
+    type: 'function',
+    name: 'attestationsByTokenId',
+    stateMutability: 'view',
+    inputs: [{ name: 'tokenId', type: 'uint256' }],
+    outputs: [
+      { name: 'modelId', type: 'bytes32' },
+      { name: 'artifactHash', type: 'bytes32' },
+      { name: 'attestationHash', type: 'bytes32' },
+      { name: 'attestationKind', type: 'bytes32' },
+      { name: 'verifier', type: 'address' },
+      { name: 'verifiedAt', type: 'uint64' },
+    ],
+  },
+  // ─── Writes ─────────────────────────────────────────────────────────
+  {
+    type: 'function',
+    name: 'registerAndVerifyAttestation',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'tokenId', type: 'uint256' },
+      { name: 'modelId', type: 'bytes32' },
+      { name: 'artifactHash', type: 'bytes32' },
+      { name: 'attestationKind', type: 'bytes32' },
+      { name: 'attestationData', type: 'bytes' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'setAttestationVerifier',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'attestationKind', type: 'bytes32' },
+      { name: 'verifier', type: 'address' },
+    ],
+    outputs: [],
+  },
+] as const;
+
+/** Minimal ERC-20 fragment for USDC approvals in the metering example. */
+export const Erc20Abi = [
+  {
+    type: 'function',
+    name: 'approve',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'spender', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+  {
+    type: 'function',
+    name: 'allowance',
+    stateMutability: 'view',
+    inputs: [
+      { name: 'owner', type: 'address' },
+      { name: 'spender', type: 'address' },
+    ],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'balanceOf',
+    stateMutability: 'view',
+    inputs: [{ name: 'account', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+] as const;

--- a/sdk/typescript/src/attestation.ts
+++ b/sdk/typescript/src/attestation.ts
@@ -1,0 +1,131 @@
+import type { Address, Hash, Hex, PublicClient, WalletClient } from 'viem';
+
+import { Erc721AiAttestationHookAbi } from './abis.js';
+import { MissingWalletError } from './errors.js';
+import type { TrainingAttestation, WriteResult } from './types.js';
+
+/**
+ * Thin wrapper around `ERC721AIAttestationHook.sol`.
+ *
+ * The on-chain contract requires a pre-configured verifier for each
+ * `attestationKind`. `registerAttestation` invokes the verifier and
+ * records the canonical attestation if it passes; `verifyAttestation` is a
+ * read-side helper that tells callers whether the attestation currently
+ * stored for a tokenId matches a claimed `(modelId, artifactHash, kind)`.
+ */
+export class AttestationModule {
+  constructor(
+    private readonly address: Address,
+    private readonly publicClient: PublicClient,
+    private readonly walletClient?: WalletClient,
+  ) {}
+
+  /** Address of the ERC721AIAttestationHook contract. */
+  get contractAddress(): Address {
+    return this.address;
+  }
+
+  // ─── Reads ──────────────────────────────────────────────────────────
+
+  async getAttestation(tokenId: bigint): Promise<TrainingAttestation> {
+    const raw = (await this.publicClient.readContract({
+      address: this.address,
+      abi: Erc721AiAttestationHookAbi,
+      functionName: 'attestationsByTokenId',
+      args: [tokenId],
+    })) as readonly [Hex, Hex, Hex, Hex, Address, bigint];
+    return {
+      modelId: raw[0],
+      artifactHash: raw[1],
+      attestationHash: raw[2],
+      attestationKind: raw[3],
+      verifier: raw[4],
+      verifiedAt: raw[5],
+    };
+  }
+
+  /**
+   * Lightweight client-side check — loads the on-chain record for
+   * `tokenId` and compares it to the expected values. Returns `true` when
+   * the stored attestation's `modelId`, `artifactHash`, and
+   * `attestationKind` all match. This does NOT re-run the verifier; for
+   * cryptographic re-verification call the off-chain proof system
+   * directly with `attestationData`.
+   */
+  async verifyAttestation(params: {
+    tokenId: bigint;
+    modelId: Hex;
+    artifactHash: Hex;
+    attestationKind: Hex;
+  }): Promise<boolean> {
+    const rec = await this.getAttestation(params.tokenId);
+    // An unset record has verifiedAt == 0 and verifier == zero address.
+    if (rec.verifiedAt === 0n) return false;
+    return (
+      rec.modelId.toLowerCase() === params.modelId.toLowerCase() &&
+      rec.artifactHash.toLowerCase() === params.artifactHash.toLowerCase() &&
+      rec.attestationKind.toLowerCase() ===
+        params.attestationKind.toLowerCase()
+    );
+  }
+
+  async attestationVerifier(attestationKind: Hex): Promise<Address> {
+    return (await this.publicClient.readContract({
+      address: this.address,
+      abi: Erc721AiAttestationHookAbi,
+      functionName: 'attestationVerifiers',
+      args: [attestationKind],
+    })) as Address;
+  }
+
+  // ─── Writes ─────────────────────────────────────────────────────────
+
+  /**
+   * Register and verify a training attestation for a token. The contract
+   * will revert if no verifier is configured for `attestationKind` or if
+   * the verifier rejects the `attestationData` payload.
+   */
+  async registerAttestation(params: {
+    tokenId: bigint;
+    modelId: Hex;
+    artifactHash: Hex;
+    attestationKind: Hex;
+    attestationData: Hex;
+  }): Promise<WriteResult> {
+    const wallet = this.requireWallet();
+    const account = wallet.account;
+    if (!account) throw new MissingWalletError();
+
+    const hash = await wallet.writeContract({
+      address: this.address,
+      abi: Erc721AiAttestationHookAbi,
+      functionName: 'registerAndVerifyAttestation',
+      args: [
+        params.tokenId,
+        params.modelId,
+        params.artifactHash,
+        params.attestationKind,
+        params.attestationData,
+      ],
+      account,
+      chain: wallet.chain ?? null,
+    });
+    return this.makeWriteResult(hash);
+  }
+
+  // ─── Internals ──────────────────────────────────────────────────────
+
+  private requireWallet(): WalletClient {
+    if (!this.walletClient) throw new MissingWalletError();
+    return this.walletClient;
+  }
+
+  private makeWriteResult(hash: Hash): WriteResult {
+    return {
+      hash,
+      wait: async () => {
+        await this.publicClient.waitForTransactionReceipt({ hash });
+      },
+    };
+  }
+}

--- a/sdk/typescript/src/chains.ts
+++ b/sdk/typescript/src/chains.ts
@@ -1,0 +1,21 @@
+import { defineChain } from 'viem';
+
+/**
+ * erc721-ai devnet placeholder. The SDK is chain-agnostic; pick any chain
+ * your viem clients target. This definition is primarily used by the test
+ * harness so that mocked EIP-1193 transports can reply with a consistent
+ * `eth_chainId`.
+ */
+export const erc721AiDevnet = defineChain({
+  id: 1339,
+  name: 'erc721-ai Devnet',
+  nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
+  rpcUrls: {
+    default: { http: ['http://127.0.0.1:8545'] },
+    public: { http: ['http://127.0.0.1:8545'] },
+  },
+  blockExplorers: {
+    default: { name: 'Blockscout (local)', url: 'http://127.0.0.1:4000' },
+  },
+  testnet: true,
+});

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,0 +1,94 @@
+import type { PublicClient, WalletClient } from 'viem';
+
+import { AttestationModule } from './attestation.js';
+import { MissingAttestationError } from './errors.js';
+import { MeteringModule } from './metering.js';
+import { ModelModule } from './model.js';
+import type { Erc721AiContracts } from './types.js';
+
+export interface CreateErc721AiClientOptions {
+  /** Contract addresses for the target deployment. */
+  contracts: Erc721AiContracts;
+  /** Public client for reads (required). */
+  publicClient: PublicClient;
+  /** Wallet client for writes (optional — read-only clients are fine). */
+  walletClient?: WalletClient;
+}
+
+/**
+ * Top-level SDK client. One handle per deployment/chain.
+ *
+ * @example
+ * ```ts
+ * import { createPublicClient, createWalletClient, http } from 'viem';
+ * import { privateKeyToAccount } from 'viem/accounts';
+ * import { createErc721AiClient } from '@kcolbchain/erc721-ai-sdk';
+ *
+ * const publicClient = createPublicClient({ transport: http() });
+ * const walletClient = createWalletClient({
+ *   transport: http(),
+ *   account: privateKeyToAccount(process.env.PK as `0x${string}`),
+ * });
+ *
+ * const ai = createErc721AiClient({
+ *   contracts: { erc721ai: '0x...', metering: '0x...' },
+ *   publicClient,
+ *   walletClient,
+ * });
+ *
+ * const { hash, wait } = await ai.model.mintModel({ ... });
+ * await wait();
+ * ```
+ */
+export interface Erc721AiClient {
+  contracts: Erc721AiContracts;
+  publicClient: PublicClient;
+  walletClient?: WalletClient;
+  model: ModelModule;
+  metering: MeteringModule;
+  /** Only available when `contracts.attestation` was configured. */
+  attestation: AttestationModule;
+}
+
+export function createErc721AiClient(
+  opts: CreateErc721AiClientOptions,
+): Erc721AiClient {
+  const { contracts, publicClient, walletClient } = opts;
+
+  const model = new ModelModule(contracts.erc721ai, publicClient, walletClient);
+  const metering = new MeteringModule(
+    contracts.metering,
+    publicClient,
+    walletClient,
+  );
+
+  // Attestation is optional. We expose it via a JS getter that throws if
+  // the caller tries to use it without providing an address — that way
+  // consumers that don't care can ignore it entirely, but misuse still
+  // surfaces a typed error instead of an opaque "undefined is not a
+  // function".
+  let cachedAttestation: AttestationModule | null = null;
+  const makeAttestation = (): AttestationModule => {
+    if (cachedAttestation) return cachedAttestation;
+    if (!contracts.attestation) throw new MissingAttestationError();
+    cachedAttestation = new AttestationModule(
+      contracts.attestation,
+      publicClient,
+      walletClient,
+    );
+    return cachedAttestation;
+  };
+
+  const base: Omit<Erc721AiClient, 'attestation'> = {
+    contracts,
+    publicClient,
+    model,
+    metering,
+    ...(walletClient !== undefined ? { walletClient } : {}),
+  };
+
+  return Object.defineProperty(base as Erc721AiClient, 'attestation', {
+    enumerable: true,
+    get: () => makeAttestation(),
+  });
+}

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -1,0 +1,47 @@
+/**
+ * SDK error hierarchy. Prefer these over raw throws so callers can catch by
+ * type without string-matching.
+ */
+
+export class Erc721AiSdkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'Erc721AiSdkError';
+  }
+}
+
+export class MissingWalletError extends Erc721AiSdkError {
+  constructor() {
+    super(
+      'This operation requires a wallet client. Pass `walletClient` to createErc721AiClient.',
+    );
+    this.name = 'MissingWalletError';
+  }
+}
+
+export class InvalidPriceError extends Erc721AiSdkError {
+  constructor(price: bigint | number) {
+    super(
+      `Inference price must be a positive integer of USDC atomic units (6 decimals); got ${String(
+        price,
+      )}.`,
+    );
+    this.name = 'InvalidPriceError';
+  }
+}
+
+export class ModelNotFoundError extends Erc721AiSdkError {
+  constructor(tokenId: bigint) {
+    super(`No model registered for tokenId ${tokenId.toString()}.`);
+    this.name = 'ModelNotFoundError';
+  }
+}
+
+export class MissingAttestationError extends Erc721AiSdkError {
+  constructor() {
+    super(
+      'No attestation hook address configured. Pass `contracts.attestation` to createErc721AiClient() to use attestation methods.',
+    );
+    this.name = 'MissingAttestationError';
+  }
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,0 +1,35 @@
+export { createErc721AiClient } from './client.js';
+export type {
+  Erc721AiClient,
+  CreateErc721AiClientOptions,
+} from './client.js';
+
+export { ModelModule } from './model.js';
+export { MeteringModule } from './metering.js';
+export { AttestationModule } from './attestation.js';
+
+export { erc721AiDevnet } from './chains.js';
+
+export {
+  Erc721AiAbi,
+  Erc721AiMeteringAbi,
+  Erc721AiAttestationHookAbi,
+  Erc20Abi,
+} from './abis.js';
+
+export type {
+  Erc721AiContracts,
+  ModelAsset,
+  MintModelParams,
+  MeteringModelInfo,
+  TrainingAttestation,
+  WriteResult,
+} from './types.js';
+
+export {
+  Erc721AiSdkError,
+  MissingWalletError,
+  InvalidPriceError,
+  ModelNotFoundError,
+  MissingAttestationError,
+} from './errors.js';

--- a/sdk/typescript/src/metering.ts
+++ b/sdk/typescript/src/metering.ts
@@ -1,0 +1,228 @@
+import type { Address, Hash, PublicClient, WalletClient } from 'viem';
+
+import { Erc721AiMeteringAbi } from './abis.js';
+import {
+  InvalidPriceError,
+  MissingWalletError,
+  ModelNotFoundError,
+} from './errors.js';
+import type { MeteringModelInfo, WriteResult } from './types.js';
+
+/**
+ * Wraps `ERC721AIx402Metering.sol` — per-inference USDC payment rails for
+ * tokenised AI models.
+ *
+ * The x402 flow expected by consumers:
+ *   1. Model owner calls `registerModel` (or any future equivalent that
+ *      seeds a `ModelConfig`), then `setInferencePrice` to adjust.
+ *   2. Caller approves USDC to the metering contract.
+ *   3. Caller invokes `payForInference(tokenId)` — `InferencePaid` is
+ *      emitted and the off-chain inference server watches for it before
+ *      serving the HTTP 402-gated response.
+ *   4. Model owner calls `withdrawRevenue()` to collect their share.
+ *
+ * USDC amounts are `uint128` atomic units (6 decimals).
+ */
+export class MeteringModule {
+  constructor(
+    private readonly address: Address,
+    private readonly publicClient: PublicClient,
+    private readonly walletClient?: WalletClient,
+  ) {}
+
+  /** Address of the ERC721AIx402Metering contract. */
+  get contractAddress(): Address {
+    return this.address;
+  }
+
+  // ─── Reads ──────────────────────────────────────────────────────────
+
+  /** USDC address this metering contract accepts. */
+  async usdc(): Promise<Address> {
+    return (await this.publicClient.readContract({
+      address: this.address,
+      abi: Erc721AiMeteringAbi,
+      functionName: 'usdc',
+    })) as Address;
+  }
+
+  /** Returns the raw USDC atomic-unit price (6 decimals). */
+  async getInferencePrice(tokenId: bigint): Promise<bigint> {
+    return (await this.publicClient.readContract({
+      address: this.address,
+      abi: Erc721AiMeteringAbi,
+      functionName: 'getInferencePrice',
+      args: [tokenId],
+    })) as bigint;
+  }
+
+  async getModelInfo(tokenId: bigint): Promise<MeteringModelInfo> {
+    const raw = (await this.publicClient.readContract({
+      address: this.address,
+      abi: Erc721AiMeteringAbi,
+      functionName: 'getModelInfo',
+      args: [tokenId],
+    })) as readonly [Address, bigint, boolean, bigint];
+    const owner = raw[0];
+    if (owner === '0x0000000000000000000000000000000000000000') {
+      throw new ModelNotFoundError(tokenId);
+    }
+    return {
+      owner,
+      pricePerInference: raw[1],
+      active: raw[2],
+      totalInferences: raw[3],
+    };
+  }
+
+  async totalInferences(tokenId: bigint): Promise<bigint> {
+    return (await this.publicClient.readContract({
+      address: this.address,
+      abi: Erc721AiMeteringAbi,
+      functionName: 'totalInferences',
+      args: [tokenId],
+    })) as bigint;
+  }
+
+  async revenueBalance(owner: Address): Promise<bigint> {
+    return (await this.publicClient.readContract({
+      address: this.address,
+      abi: Erc721AiMeteringAbi,
+      functionName: 'revenueBalance',
+      args: [owner],
+    })) as bigint;
+  }
+
+  async protocolFeeBps(): Promise<number> {
+    const raw = (await this.publicClient.readContract({
+      address: this.address,
+      abi: Erc721AiMeteringAbi,
+      functionName: 'protocolFeeBps',
+    })) as number;
+    return Number(raw);
+  }
+
+  // ─── Writes ─────────────────────────────────────────────────────────
+
+  /**
+   * Register a model for metering, seeding its initial price. The caller
+   * becomes the revenue recipient (per the contract's `msg.sender`-based
+   * ownership model).
+   */
+  async registerModel(params: {
+    tokenId: bigint;
+    pricePerInference: bigint;
+  }): Promise<WriteResult> {
+    this.assertPositivePrice(params.pricePerInference);
+    const wallet = this.requireWallet();
+    const account = wallet.account;
+    if (!account) throw new MissingWalletError();
+
+    const hash = await wallet.writeContract({
+      address: this.address,
+      abi: Erc721AiMeteringAbi,
+      functionName: 'registerModel',
+      args: [params.tokenId, params.pricePerInference],
+      account,
+      chain: wallet.chain ?? null,
+    });
+    return this.makeWriteResult(hash);
+  }
+
+  /** Update the per-inference price. Only the registered model owner may call. */
+  async setInferencePrice(params: {
+    tokenId: bigint;
+    newPrice: bigint;
+  }): Promise<WriteResult> {
+    this.assertPositivePrice(params.newPrice);
+    const wallet = this.requireWallet();
+    const account = wallet.account;
+    if (!account) throw new MissingWalletError();
+
+    const hash = await wallet.writeContract({
+      address: this.address,
+      abi: Erc721AiMeteringAbi,
+      functionName: 'setInferencePrice',
+      args: [params.tokenId, params.newPrice],
+      account,
+      chain: wallet.chain ?? null,
+    });
+    return this.makeWriteResult(hash);
+  }
+
+  /** Pay for a single inference. Caller must have approved USDC first. */
+  async payForInference(tokenId: bigint): Promise<WriteResult> {
+    const wallet = this.requireWallet();
+    const account = wallet.account;
+    if (!account) throw new MissingWalletError();
+
+    const hash = await wallet.writeContract({
+      address: this.address,
+      abi: Erc721AiMeteringAbi,
+      functionName: 'payForInference',
+      args: [tokenId],
+      account,
+      chain: wallet.chain ?? null,
+    });
+    return this.makeWriteResult(hash);
+  }
+
+  /** Pay for N inferences at once. */
+  async payForInferences(params: {
+    tokenId: bigint;
+    count: bigint;
+  }): Promise<WriteResult> {
+    const wallet = this.requireWallet();
+    const account = wallet.account;
+    if (!account) throw new MissingWalletError();
+
+    const hash = await wallet.writeContract({
+      address: this.address,
+      abi: Erc721AiMeteringAbi,
+      functionName: 'payForInferences',
+      args: [params.tokenId, params.count],
+      account,
+      chain: wallet.chain ?? null,
+    });
+    return this.makeWriteResult(hash);
+  }
+
+  /** Withdraw accumulated USDC revenue to the caller. */
+  async withdrawRevenue(): Promise<WriteResult> {
+    const wallet = this.requireWallet();
+    const account = wallet.account;
+    if (!account) throw new MissingWalletError();
+
+    const hash = await wallet.writeContract({
+      address: this.address,
+      abi: Erc721AiMeteringAbi,
+      functionName: 'withdrawRevenue',
+      args: [],
+      account,
+      chain: wallet.chain ?? null,
+    });
+    return this.makeWriteResult(hash);
+  }
+
+  // ─── Internals ──────────────────────────────────────────────────────
+
+  private assertPositivePrice(price: bigint): void {
+    if (price <= 0n) throw new InvalidPriceError(price);
+    // uint128 upper bound.
+    if (price >= 1n << 128n) throw new InvalidPriceError(price);
+  }
+
+  private requireWallet(): WalletClient {
+    if (!this.walletClient) throw new MissingWalletError();
+    return this.walletClient;
+  }
+
+  private makeWriteResult(hash: Hash): WriteResult {
+    return {
+      hash,
+      wait: async () => {
+        await this.publicClient.waitForTransactionReceipt({ hash });
+      },
+    };
+  }
+}

--- a/sdk/typescript/src/model.ts
+++ b/sdk/typescript/src/model.ts
@@ -1,0 +1,206 @@
+import type { Address, Hash, Hex, PublicClient, WalletClient } from 'viem';
+
+import { Erc721AiAbi } from './abis.js';
+import { MissingWalletError } from './errors.js';
+import type { MintModelParams, ModelAsset, WriteResult } from './types.js';
+
+/**
+ * Wraps the `ERC721AI.sol` reference contract. Surfaces the model-asset
+ * lifecycle plus the ERC-721 reads most consumers need.
+ *
+ * Reads go through `publicClient`; writes require `walletClient`.
+ */
+export class ModelModule {
+  constructor(
+    private readonly address: Address,
+    private readonly publicClient: PublicClient,
+    private readonly walletClient?: WalletClient,
+  ) {}
+
+  /** Address of the ERC721AI contract. */
+  get contractAddress(): Address {
+    return this.address;
+  }
+
+  // ─── Reads ──────────────────────────────────────────────────────────
+
+  async ownerOf(tokenId: bigint): Promise<Address> {
+    return (await this.publicClient.readContract({
+      address: this.address,
+      abi: Erc721AiAbi,
+      functionName: 'ownerOf',
+      args: [tokenId],
+    })) as Address;
+  }
+
+  /**
+   * The reference `ERC721AI.sol` does not expose a canonical `tokenURI` —
+   * it stores a `weightsCID` on the model-asset record. Callers that need
+   * an ERC-721 Metadata JSON pointer typically want the off-chain resolver
+   * URI derived from that CID. This helper returns `ipfs://<weightsCID>`
+   * when a CID is present; override or extend for other gateways.
+   */
+  async tokenURI(tokenId: bigint): Promise<string> {
+    const asset = await this.modelAsset(tokenId);
+    if (!asset.weightsCID) return '';
+    // Preserve existing scheme if the CID is already a URI.
+    if (/^[a-z][a-z0-9+\-.]*:\/\//i.test(asset.weightsCID)) {
+      return asset.weightsCID;
+    }
+    return `ipfs://${asset.weightsCID}`;
+  }
+
+  async modelAsset(tokenId: bigint): Promise<ModelAsset> {
+    const raw = (await this.publicClient.readContract({
+      address: this.address,
+      abi: Erc721AiAbi,
+      functionName: 'modelAsset',
+      args: [tokenId],
+    })) as readonly [
+      Hex, // modelId
+      Hex, // artifactHash
+      Hex, // baseModel
+      string, // weightsCID
+      string, // architecture
+      string, // license
+      string, // inferenceEndpoint
+      number, // creatorRoyaltyBps
+      bigint, // createdAt
+      Address, // creator
+    ];
+    return {
+      modelId: raw[0],
+      artifactHash: raw[1],
+      baseModel: raw[2],
+      weightsCID: raw[3],
+      architecture: raw[4],
+      license: raw[5],
+      inferenceEndpoint: raw[6],
+      creatorRoyaltyBps: Number(raw[7]),
+      createdAt: raw[8],
+      creator: raw[9],
+    };
+  }
+
+  async royaltyInfo(
+    tokenId: bigint,
+    salePrice: bigint,
+  ): Promise<{ receiver: Address; royaltyAmount: bigint }> {
+    const raw = (await this.publicClient.readContract({
+      address: this.address,
+      abi: Erc721AiAbi,
+      functionName: 'royaltyInfo',
+      args: [tokenId, salePrice],
+    })) as readonly [Address, bigint];
+    return { receiver: raw[0], royaltyAmount: raw[1] };
+  }
+
+  async tokenIdByModelId(modelId: Hex): Promise<bigint> {
+    return (await this.publicClient.readContract({
+      address: this.address,
+      abi: Erc721AiAbi,
+      functionName: 'tokenIdByModelId',
+      args: [modelId],
+    })) as bigint;
+  }
+
+  async totalSupply(): Promise<bigint> {
+    return (await this.publicClient.readContract({
+      address: this.address,
+      abi: Erc721AiAbi,
+      functionName: 'totalSupply',
+    })) as bigint;
+  }
+
+  // ─── Writes ─────────────────────────────────────────────────────────
+
+  /**
+   * Mint a new tokenised model asset.
+   *
+   * The caller becomes `creator` and, unless `to` differs, the initial
+   * token owner. `creatorRoyaltyBps` is capped at 10_000 (100%) by the
+   * contract; this method does not pre-validate it so reverts surface
+   * with the contract's own error.
+   */
+  async mintModel(params: MintModelParams): Promise<WriteResult> {
+    const wallet = this.requireWallet();
+    const account = wallet.account;
+    if (!account) throw new MissingWalletError();
+
+    const hash = await wallet.writeContract({
+      address: this.address,
+      abi: Erc721AiAbi,
+      functionName: 'mintModel',
+      args: [
+        params.to,
+        params.modelId,
+        params.artifactHash,
+        params.baseModel,
+        params.weightsCID,
+        params.architecture,
+        params.license,
+        params.inferenceEndpoint,
+        params.creatorRoyaltyBps,
+      ],
+      account,
+      chain: wallet.chain ?? null,
+    });
+    return this.makeWriteResult(hash);
+  }
+
+  /** Update the inference endpoint. Only the current token owner may call. */
+  async setInferenceEndpoint(params: {
+    tokenId: bigint;
+    endpoint: string;
+  }): Promise<WriteResult> {
+    const wallet = this.requireWallet();
+    const account = wallet.account;
+    if (!account) throw new MissingWalletError();
+
+    const hash = await wallet.writeContract({
+      address: this.address,
+      abi: Erc721AiAbi,
+      functionName: 'setInferenceEndpoint',
+      args: [params.tokenId, params.endpoint],
+      account,
+      chain: wallet.chain ?? null,
+    });
+    return this.makeWriteResult(hash);
+  }
+
+  /** Record the attestation kind for a token. Only the original creator may call. */
+  async setAttestationKind(params: {
+    tokenId: bigint;
+    kind: Hex;
+  }): Promise<WriteResult> {
+    const wallet = this.requireWallet();
+    const account = wallet.account;
+    if (!account) throw new MissingWalletError();
+
+    const hash = await wallet.writeContract({
+      address: this.address,
+      abi: Erc721AiAbi,
+      functionName: 'setAttestationKind',
+      args: [params.tokenId, params.kind],
+      account,
+      chain: wallet.chain ?? null,
+    });
+    return this.makeWriteResult(hash);
+  }
+
+  // ─── Internals ──────────────────────────────────────────────────────
+
+  private requireWallet(): WalletClient {
+    if (!this.walletClient) throw new MissingWalletError();
+    return this.walletClient;
+  }
+
+  private makeWriteResult(hash: Hash): WriteResult {
+    return {
+      hash,
+      wait: async () => {
+        await this.publicClient.waitForTransactionReceipt({ hash });
+      },
+    };
+  }
+}

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1,0 +1,82 @@
+import type { Address, Hash, Hex } from 'viem';
+
+/**
+ * Deployment addresses for a given erc721-ai target.
+ *
+ * - `erc721ai` — the `ERC721AI` model-asset NFT contract (required).
+ * - `metering` — the `ERC721AIx402Metering` per-inference USDC contract
+ *   (required for `MeteringModule`).
+ * - `attestation` — the `ERC721AIAttestationHook` contract (optional; only
+ *   needed if you use `AttestationModule`).
+ */
+export interface Erc721AiContracts {
+  erc721ai: Address;
+  metering: Address;
+  attestation?: Address;
+}
+
+/**
+ * On-chain representation of a tokenised model asset, as returned by
+ * `ERC721AI.modelAsset(tokenId)`.
+ */
+export interface ModelAsset {
+  modelId: Hex;
+  artifactHash: Hex;
+  baseModel: Hex;
+  weightsCID: string;
+  architecture: string;
+  license: string;
+  inferenceEndpoint: string;
+  creatorRoyaltyBps: number;
+  createdAt: bigint;
+  creator: Address;
+}
+
+/** Parameters for `ModelModule.mintModel`. */
+export interface MintModelParams {
+  to: Address;
+  modelId: Hex;
+  artifactHash: Hex;
+  /** 0x00..0 when this is a root model (no base). */
+  baseModel: Hex;
+  weightsCID: string;
+  architecture: string;
+  license: string;
+  inferenceEndpoint: string;
+  /** Basis points, 0-10000. */
+  creatorRoyaltyBps: number;
+}
+
+/**
+ * On-chain metering record for a tokenised model, as returned by
+ * `ERC721AIx402Metering.getModelInfo(tokenId)`.
+ */
+export interface MeteringModelInfo {
+  owner: Address;
+  /** Price in USDC atomic units (6 decimals). */
+  pricePerInference: bigint;
+  active: boolean;
+  totalInferences: bigint;
+}
+
+/**
+ * Attestation record, as returned by
+ * `ERC721AIAttestationHook.attestationsByTokenId(tokenId)`.
+ */
+export interface TrainingAttestation {
+  modelId: Hex;
+  artifactHash: Hex;
+  attestationHash: Hex;
+  attestationKind: Hex;
+  verifier: Address;
+  verifiedAt: bigint;
+}
+
+/**
+ * Common return shape for write methods — a transaction hash plus a helper
+ * that resolves once the transaction is confirmed.
+ */
+export interface WriteResult {
+  hash: Hash;
+  wait: () => Promise<void>;
+}

--- a/sdk/typescript/test/attestation.test.ts
+++ b/sdk/typescript/test/attestation.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decodeFunctionData,
+  encodeFunctionResult,
+  type Address,
+  type Hex,
+} from 'viem';
+
+import { createErc721AiClient } from '../src/client.js';
+import { MissingAttestationError } from '../src/errors.js';
+import { Erc721AiAttestationHookAbi, makeHarness } from './helpers.js';
+
+const ERC721AI: Address = '0xabcabcabcabcabcabcabcabcabcabcabcabcabca';
+const METERING: Address = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+const HOOK: Address = '0xfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed';
+
+const MODEL_ID: Hex = `0x${'11'.repeat(32)}`;
+const ARTIFACT_HASH: Hex = `0x${'22'.repeat(32)}`;
+const ATTEST_KIND: Hex = `0x${'33'.repeat(32)}`;
+const ATTEST_HASH: Hex = `0x${'44'.repeat(32)}`;
+const VERIFIER: Address = '0x9999999999999999999999999999999999999999';
+
+describe('AttestationModule', () => {
+  it('throws MissingAttestationError when attestation address is omitted', () => {
+    const harness = makeHarness();
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+      walletClient: harness.walletClient,
+    });
+    expect(() => ai.attestation).toThrow(MissingAttestationError);
+  });
+
+  it('decodes getAttestation', async () => {
+    const harness = makeHarness({
+      eth_call: () =>
+        encodeFunctionResult({
+          abi: Erc721AiAttestationHookAbi,
+          functionName: 'attestationsByTokenId',
+          result: [
+            MODEL_ID,
+            ARTIFACT_HASH,
+            ATTEST_HASH,
+            ATTEST_KIND,
+            VERIFIER,
+            1_700_000_000n,
+          ],
+        }) as Hex,
+    });
+    const ai = createErc721AiClient({
+      contracts: {
+        erc721ai: ERC721AI,
+        metering: METERING,
+        attestation: HOOK,
+      },
+      publicClient: harness.publicClient,
+    });
+    const rec = await ai.attestation.getAttestation(1n);
+    expect(rec.modelId).toBe(MODEL_ID);
+    expect(rec.artifactHash).toBe(ARTIFACT_HASH);
+    expect(rec.attestationHash).toBe(ATTEST_HASH);
+    expect(rec.attestationKind).toBe(ATTEST_KIND);
+    expect(rec.verifier.toLowerCase()).toBe(VERIFIER.toLowerCase());
+    expect(rec.verifiedAt).toBe(1_700_000_000n);
+  });
+
+  it('verifyAttestation returns true on matching (modelId, artifactHash, kind)', async () => {
+    const harness = makeHarness({
+      eth_call: () =>
+        encodeFunctionResult({
+          abi: Erc721AiAttestationHookAbi,
+          functionName: 'attestationsByTokenId',
+          result: [
+            MODEL_ID,
+            ARTIFACT_HASH,
+            ATTEST_HASH,
+            ATTEST_KIND,
+            VERIFIER,
+            1_700_000_000n,
+          ],
+        }) as Hex,
+    });
+    const ai = createErc721AiClient({
+      contracts: {
+        erc721ai: ERC721AI,
+        metering: METERING,
+        attestation: HOOK,
+      },
+      publicClient: harness.publicClient,
+    });
+    const ok = await ai.attestation.verifyAttestation({
+      tokenId: 1n,
+      modelId: MODEL_ID,
+      artifactHash: ARTIFACT_HASH,
+      attestationKind: ATTEST_KIND,
+    });
+    expect(ok).toBe(true);
+  });
+
+  it('verifyAttestation returns false when the record is unset', async () => {
+    const ZERO: Hex = `0x${'00'.repeat(32)}`;
+    const ZERO_ADDR: Address = '0x0000000000000000000000000000000000000000';
+    const harness = makeHarness({
+      eth_call: () =>
+        encodeFunctionResult({
+          abi: Erc721AiAttestationHookAbi,
+          functionName: 'attestationsByTokenId',
+          result: [ZERO, ZERO, ZERO, ZERO, ZERO_ADDR, 0n],
+        }) as Hex,
+    });
+    const ai = createErc721AiClient({
+      contracts: {
+        erc721ai: ERC721AI,
+        metering: METERING,
+        attestation: HOOK,
+      },
+      publicClient: harness.publicClient,
+    });
+    const ok = await ai.attestation.verifyAttestation({
+      tokenId: 1n,
+      modelId: MODEL_ID,
+      artifactHash: ARTIFACT_HASH,
+      attestationKind: ATTEST_KIND,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('sends registerAttestation with the full payload', async () => {
+    const harness = makeHarness();
+    const ai = createErc721AiClient({
+      contracts: {
+        erc721ai: ERC721AI,
+        metering: METERING,
+        attestation: HOOK,
+      },
+      publicClient: harness.publicClient,
+      walletClient: harness.walletClient,
+    });
+    const data: Hex = '0xdeadbeef';
+    await ai.attestation.registerAttestation({
+      tokenId: 5n,
+      modelId: MODEL_ID,
+      artifactHash: ARTIFACT_HASH,
+      attestationKind: ATTEST_KIND,
+      attestationData: data,
+    });
+    const tx = harness.provider.sentTxs[0]!;
+    expect(tx.to?.toLowerCase()).toBe(HOOK.toLowerCase());
+    const decoded = decodeFunctionData({
+      abi: Erc721AiAttestationHookAbi,
+      data: tx.data!,
+    });
+    expect(decoded.functionName).toBe('registerAndVerifyAttestation');
+    const args = decoded.args as readonly unknown[];
+    expect(args[0]).toBe(5n);
+    expect(args[1]).toBe(MODEL_ID);
+    expect(args[2]).toBe(ARTIFACT_HASH);
+    expect(args[3]).toBe(ATTEST_KIND);
+    expect(args[4]).toBe(data);
+  });
+});

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import type { Address } from 'viem';
+
+import { createErc721AiClient } from '../src/client.js';
+import { makeHarness } from './helpers.js';
+
+const ERC721AI: Address = '0xabcabcabcabcabcabcabcabcabcabcabcabcabca';
+const METERING: Address = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+const HOOK: Address = '0xfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed';
+
+describe('createErc721AiClient', () => {
+  it('exposes model and metering module handles with the right addresses', () => {
+    const harness = makeHarness();
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+    });
+    expect(ai.model.contractAddress.toLowerCase()).toBe(
+      ERC721AI.toLowerCase(),
+    );
+    expect(ai.metering.contractAddress.toLowerCase()).toBe(
+      METERING.toLowerCase(),
+    );
+  });
+
+  it('caches the attestation module across accesses', () => {
+    const harness = makeHarness();
+    const ai = createErc721AiClient({
+      contracts: {
+        erc721ai: ERC721AI,
+        metering: METERING,
+        attestation: HOOK,
+      },
+      publicClient: harness.publicClient,
+    });
+    const a = ai.attestation;
+    const b = ai.attestation;
+    expect(a).toBe(b);
+    expect(a.contractAddress.toLowerCase()).toBe(HOOK.toLowerCase());
+  });
+});

--- a/sdk/typescript/test/helpers.ts
+++ b/sdk/typescript/test/helpers.ts
@@ -1,0 +1,187 @@
+import {
+  createPublicClient,
+  createWalletClient,
+  custom,
+  parseTransaction,
+  type Address,
+  type Hex,
+  type PublicClient,
+  type WalletClient,
+} from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { erc721AiDevnet } from '../src/chains.js';
+import {
+  Erc721AiAbi,
+  Erc721AiAttestationHookAbi,
+  Erc721AiMeteringAbi,
+} from '../src/abis.js';
+
+/**
+ * Minimal in-memory EIP-1193 provider for unit tests. Records every call
+ * so tests can assert on `eth_sendTransaction` / `eth_sendRawTransaction`
+ * args and return canned values for reads.
+ *
+ * This is raw-tx aware: viem WalletClients backed by a private-key account
+ * sign locally and broadcast via `eth_sendRawTransaction`, which we parse
+ * and record in `sentTxs` so assertions can look at the decoded calldata.
+ */
+export interface MockCall {
+  method: string;
+  params: unknown[];
+}
+
+export interface MockProviderHandlers {
+  eth_call?: (args: { to: Address; data: Hex }) => Hex;
+  eth_getTransactionReceipt?: (hash: Hex) => unknown;
+}
+
+type AnyRequest = (args: { method: string; params?: unknown }) => Promise<unknown>;
+
+export function createMockProvider(handlers: MockProviderHandlers = {}): {
+  request: AnyRequest;
+  calls: MockCall[];
+  sentTxs: Array<{ to: Address; data?: Hex; value?: Hex }>;
+  setNextTxHash: (h: Hex) => void;
+} {
+  const calls: MockCall[] = [];
+  const sentTxs: Array<{ to: Address; data?: Hex; value?: Hex }> = [];
+  let nextTxHash: Hex =
+    '0x0000000000000000000000000000000000000000000000000000000000000001';
+
+  const request: AnyRequest = async ({ method, params }) => {
+    calls.push({ method, params: (params ?? []) as unknown[] });
+
+    switch (method) {
+      case 'eth_chainId':
+        return ('0x' + erc721AiDevnet.id.toString(16)) as Hex;
+      case 'eth_blockNumber':
+        return '0x1' as Hex;
+      case 'eth_gasPrice':
+        return '0x3b9aca00' as Hex;
+      case 'eth_maxPriorityFeePerGas':
+        return '0x3b9aca00' as Hex;
+      case 'eth_estimateGas':
+        return '0x5208' as Hex;
+      case 'eth_getBlockByNumber':
+        return {
+          number: '0x1',
+          hash: '0x' + 'aa'.repeat(32),
+          parentHash: '0x' + 'bb'.repeat(32),
+          timestamp: '0x0',
+          baseFeePerGas: '0x3b9aca00',
+          gasLimit: '0x1c9c380',
+          gasUsed: '0x0',
+          miner: '0x' + '00'.repeat(20),
+          extraData: '0x',
+          transactions: [],
+          transactionsRoot: '0x' + '00'.repeat(32),
+          stateRoot: '0x' + '00'.repeat(32),
+          receiptsRoot: '0x' + '00'.repeat(32),
+          logsBloom: '0x' + '00'.repeat(256),
+          difficulty: '0x0',
+          totalDifficulty: '0x0',
+          size: '0x0',
+          nonce: '0x0000000000000000',
+          mixHash: '0x' + '00'.repeat(32),
+          sha3Uncles: '0x' + '00'.repeat(32),
+          uncles: [],
+        };
+      case 'eth_getTransactionCount':
+        return '0x0' as Hex;
+      case 'eth_call': {
+        const [callObj] = (params ?? []) as [
+          { to: Address; data: Hex } | undefined,
+        ];
+        if (!callObj) throw new Error('eth_call: missing params');
+        if (handlers.eth_call) return handlers.eth_call(callObj);
+        // default: return empty 32-byte payload
+        return '0x' + '00'.repeat(32);
+      }
+      case 'eth_sendRawTransaction': {
+        const [raw] = (params ?? []) as [Hex];
+        try {
+          const parsed = parseTransaction(raw);
+          const rec: { to: Address; data?: Hex; value?: Hex } = {
+            to: (parsed.to ?? ('0x' + '00'.repeat(20))) as Address,
+          };
+          if (parsed.data !== undefined) rec.data = parsed.data as Hex;
+          rec.value =
+            parsed.value !== undefined
+              ? (('0x' + parsed.value.toString(16)) as Hex)
+              : ('0x0' as Hex);
+          sentTxs.push(rec);
+        } catch {
+          // best-effort
+        }
+        return nextTxHash;
+      }
+      case 'eth_sendTransaction': {
+        const [txObj] = (params ?? []) as [
+          { to: Address; data?: Hex; value?: Hex } | undefined,
+        ];
+        if (txObj) sentTxs.push(txObj);
+        return nextTxHash;
+      }
+      case 'eth_getTransactionReceipt': {
+        const [hash] = (params ?? []) as [Hex];
+        if (handlers.eth_getTransactionReceipt) {
+          return handlers.eth_getTransactionReceipt(hash);
+        }
+        return {
+          blockHash: '0x' + 'cc'.repeat(32),
+          blockNumber: '0x1',
+          contractAddress: null,
+          cumulativeGasUsed: '0x5208',
+          effectiveGasPrice: '0x3b9aca00',
+          from: '0x' + '11'.repeat(20),
+          gasUsed: '0x5208',
+          logs: [],
+          logsBloom: '0x' + '00'.repeat(256),
+          status: '0x1',
+          to: '0x' + '22'.repeat(20),
+          transactionHash: hash,
+          transactionIndex: '0x0',
+          type: '0x0',
+        };
+      }
+      default:
+        return null;
+    }
+  };
+
+  return {
+    request,
+    calls,
+    sentTxs,
+    setNextTxHash: (h: Hex) => {
+      nextTxHash = h;
+    },
+  };
+}
+
+export interface TestHarness {
+  publicClient: PublicClient;
+  walletClient: WalletClient;
+  provider: ReturnType<typeof createMockProvider>;
+  account: ReturnType<typeof privateKeyToAccount>;
+}
+
+export function makeHarness(handlers: MockProviderHandlers = {}): TestHarness {
+  const provider = createMockProvider(handlers);
+  const account = privateKeyToAccount(
+    '0x0101010101010101010101010101010101010101010101010101010101010101',
+  );
+  const publicClient = createPublicClient({
+    chain: erc721AiDevnet,
+    transport: custom({ request: provider.request }),
+  });
+  const walletClient = createWalletClient({
+    chain: erc721AiDevnet,
+    account,
+    transport: custom({ request: provider.request }),
+  });
+  return { publicClient, walletClient, provider, account };
+}
+
+export { Erc721AiAbi, Erc721AiMeteringAbi, Erc721AiAttestationHookAbi };

--- a/sdk/typescript/test/metering.test.ts
+++ b/sdk/typescript/test/metering.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decodeFunctionData,
+  encodeFunctionResult,
+  type Address,
+  type Hex,
+} from 'viem';
+
+import { createErc721AiClient } from '../src/client.js';
+import {
+  InvalidPriceError,
+  ModelNotFoundError,
+} from '../src/errors.js';
+import { Erc721AiMeteringAbi, makeHarness } from './helpers.js';
+
+const ERC721AI: Address = '0xabcabcabcabcabcabcabcabcabcabcabcabcabca';
+const METERING: Address = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+
+describe('MeteringModule — reads', () => {
+  it('decodes getInferencePrice', async () => {
+    const harness = makeHarness({
+      eth_call: () =>
+        encodeFunctionResult({
+          abi: Erc721AiMeteringAbi,
+          functionName: 'getInferencePrice',
+          result: 100_000n, // 0.10 USDC
+        }) as Hex,
+    });
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+    });
+    expect(await ai.metering.getInferencePrice(1n)).toBe(100_000n);
+  });
+
+  it('decodes getModelInfo into a typed record', async () => {
+    const owner: Address = '0x7777777777777777777777777777777777777777';
+    const harness = makeHarness({
+      eth_call: () =>
+        encodeFunctionResult({
+          abi: Erc721AiMeteringAbi,
+          functionName: 'getModelInfo',
+          result: [owner, 50_000n, true, 42n],
+        }) as Hex,
+    });
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+    });
+    const info = await ai.metering.getModelInfo(1n);
+    expect(info.owner.toLowerCase()).toBe(owner.toLowerCase());
+    expect(info.pricePerInference).toBe(50_000n);
+    expect(info.active).toBe(true);
+    expect(info.totalInferences).toBe(42n);
+  });
+
+  it('throws ModelNotFoundError when getModelInfo returns the zero owner', async () => {
+    const harness = makeHarness({
+      eth_call: () =>
+        encodeFunctionResult({
+          abi: Erc721AiMeteringAbi,
+          functionName: 'getModelInfo',
+          result: [
+            '0x0000000000000000000000000000000000000000',
+            0n,
+            false,
+            0n,
+          ],
+        }) as Hex,
+    });
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+    });
+    await expect(ai.metering.getModelInfo(99n)).rejects.toBeInstanceOf(
+      ModelNotFoundError,
+    );
+  });
+
+  it('decodes totalInferences and revenueBalance', async () => {
+    const owner: Address = '0x7777777777777777777777777777777777777777';
+    const harness1 = makeHarness({
+      eth_call: () =>
+        encodeFunctionResult({
+          abi: Erc721AiMeteringAbi,
+          functionName: 'totalInferences',
+          result: 7n,
+        }) as Hex,
+    });
+    const ai1 = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness1.publicClient,
+    });
+    expect(await ai1.metering.totalInferences(1n)).toBe(7n);
+
+    const harness2 = makeHarness({
+      eth_call: () =>
+        encodeFunctionResult({
+          abi: Erc721AiMeteringAbi,
+          functionName: 'revenueBalance',
+          result: 1_234_567n,
+        }) as Hex,
+    });
+    const ai2 = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness2.publicClient,
+    });
+    expect(await ai2.metering.revenueBalance(owner)).toBe(1_234_567n);
+  });
+});
+
+describe('MeteringModule — writes', () => {
+  it('rejects a zero inference price', async () => {
+    const harness = makeHarness();
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+      walletClient: harness.walletClient,
+    });
+    await expect(
+      ai.metering.setInferencePrice({ tokenId: 1n, newPrice: 0n }),
+    ).rejects.toBeInstanceOf(InvalidPriceError);
+  });
+
+  it('rejects a negative inference price', async () => {
+    const harness = makeHarness();
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+      walletClient: harness.walletClient,
+    });
+    await expect(
+      ai.metering.registerModel({ tokenId: 1n, pricePerInference: -1n }),
+    ).rejects.toBeInstanceOf(InvalidPriceError);
+  });
+
+  it('sends setInferencePrice with the uint128 price', async () => {
+    const harness = makeHarness();
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+      walletClient: harness.walletClient,
+    });
+    await ai.metering.setInferencePrice({ tokenId: 1n, newPrice: 50_000n });
+    const tx = harness.provider.sentTxs[0]!;
+    expect(tx.to?.toLowerCase()).toBe(METERING.toLowerCase());
+    const decoded = decodeFunctionData({
+      abi: Erc721AiMeteringAbi,
+      data: tx.data!,
+    });
+    expect(decoded.functionName).toBe('setInferencePrice');
+    expect(decoded.args?.[0]).toBe(1n);
+    expect(decoded.args?.[1]).toBe(50_000n);
+  });
+
+  it('sends payForInference against the metering address', async () => {
+    const harness = makeHarness();
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+      walletClient: harness.walletClient,
+    });
+    await ai.metering.payForInference(7n);
+    const tx = harness.provider.sentTxs[0]!;
+    expect(tx.to?.toLowerCase()).toBe(METERING.toLowerCase());
+    const decoded = decodeFunctionData({
+      abi: Erc721AiMeteringAbi,
+      data: tx.data!,
+    });
+    expect(decoded.functionName).toBe('payForInference');
+    expect(decoded.args?.[0]).toBe(7n);
+  });
+
+  it('sends withdrawRevenue with no args', async () => {
+    const harness = makeHarness();
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+      walletClient: harness.walletClient,
+    });
+    await ai.metering.withdrawRevenue();
+    const tx = harness.provider.sentTxs[0]!;
+    const decoded = decodeFunctionData({
+      abi: Erc721AiMeteringAbi,
+      data: tx.data!,
+    });
+    expect(decoded.functionName).toBe('withdrawRevenue');
+    expect(decoded.args ?? []).toEqual([]);
+  });
+});

--- a/sdk/typescript/test/model.test.ts
+++ b/sdk/typescript/test/model.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decodeFunctionData,
+  encodeAbiParameters,
+  encodeFunctionResult,
+  type Address,
+  type Hex,
+} from 'viem';
+
+import { createErc721AiClient } from '../src/client.js';
+import { MissingWalletError } from '../src/errors.js';
+import { Erc721AiAbi, makeHarness } from './helpers.js';
+
+const ERC721AI: Address = '0xabcabcabcabcabcabcabcabcabcabcabcabcabca';
+const METERING: Address = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+
+const MODEL_ID: Hex = `0x${'11'.repeat(32)}`;
+const ARTIFACT_HASH: Hex = `0x${'22'.repeat(32)}`;
+const BASE_MODEL: Hex = `0x${'00'.repeat(32)}`;
+const ATTEST_KIND: Hex = `0x${'33'.repeat(32)}`;
+
+describe('ModelModule — reads', () => {
+  it('decodes ownerOf', async () => {
+    const expected: Address = '0x1111111111111111111111111111111111111111';
+    const harness = makeHarness({
+      eth_call: () =>
+        encodeAbiParameters([{ type: 'address' }], [expected]) as Hex,
+    });
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+      walletClient: harness.walletClient,
+    });
+    const got = await ai.model.ownerOf(7n);
+    expect(got.toLowerCase()).toBe(expected.toLowerCase());
+  });
+
+  it('decodes modelAsset into a typed record', async () => {
+    const creator: Address = '0x2222222222222222222222222222222222222222';
+    const harness = makeHarness({
+      eth_call: () =>
+        encodeFunctionResult({
+          abi: Erc721AiAbi,
+          functionName: 'modelAsset',
+          result: [
+            MODEL_ID,
+            ARTIFACT_HASH,
+            BASE_MODEL,
+            'bafybeigweights',
+            'llama-7b',
+            'Apache-2.0',
+            'https://infer.example.com',
+            750,
+            1_700_000_000n,
+            creator,
+          ],
+        }) as Hex,
+    });
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+    });
+    const asset = await ai.model.modelAsset(1n);
+    expect(asset.modelId).toBe(MODEL_ID);
+    expect(asset.artifactHash).toBe(ARTIFACT_HASH);
+    expect(asset.weightsCID).toBe('bafybeigweights');
+    expect(asset.architecture).toBe('llama-7b');
+    expect(asset.license).toBe('Apache-2.0');
+    expect(asset.inferenceEndpoint).toBe('https://infer.example.com');
+    expect(asset.creatorRoyaltyBps).toBe(750);
+    expect(asset.createdAt).toBe(1_700_000_000n);
+    expect(asset.creator.toLowerCase()).toBe(creator.toLowerCase());
+  });
+
+  it('synthesises tokenURI from weightsCID as ipfs://…', async () => {
+    const creator: Address = '0x2222222222222222222222222222222222222222';
+    const harness = makeHarness({
+      eth_call: () =>
+        encodeFunctionResult({
+          abi: Erc721AiAbi,
+          functionName: 'modelAsset',
+          result: [
+            MODEL_ID,
+            ARTIFACT_HASH,
+            BASE_MODEL,
+            'bafybeigweights',
+            'llama-7b',
+            'MIT',
+            '',
+            0,
+            0n,
+            creator,
+          ],
+        }) as Hex,
+    });
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+    });
+    const uri = await ai.model.tokenURI(1n);
+    expect(uri).toBe('ipfs://bafybeigweights');
+  });
+
+  it('decodes royaltyInfo per ERC-2981', async () => {
+    const rec: Address = '0x4444444444444444444444444444444444444444';
+    const harness = makeHarness({
+      eth_call: () =>
+        encodeFunctionResult({
+          abi: Erc721AiAbi,
+          functionName: 'royaltyInfo',
+          result: [rec, 7_500n],
+        }) as Hex,
+    });
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+    });
+    const info = await ai.model.royaltyInfo(1n, 100_000n);
+    expect(info.receiver.toLowerCase()).toBe(rec.toLowerCase());
+    expect(info.royaltyAmount).toBe(7_500n);
+  });
+});
+
+describe('ModelModule — writes', () => {
+  it('rejects writes when no wallet is configured', async () => {
+    const harness = makeHarness();
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+    });
+    await expect(
+      ai.model.mintModel({
+        to: '0x1111111111111111111111111111111111111111',
+        modelId: MODEL_ID,
+        artifactHash: ARTIFACT_HASH,
+        baseModel: BASE_MODEL,
+        weightsCID: 'bafy',
+        architecture: 'llama-7b',
+        license: 'MIT',
+        inferenceEndpoint: '',
+        creatorRoyaltyBps: 500,
+      }),
+    ).rejects.toBeInstanceOf(MissingWalletError);
+  });
+
+  it('sends mintModel with correct calldata', async () => {
+    const harness = makeHarness();
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+      walletClient: harness.walletClient,
+    });
+    const { hash } = await ai.model.mintModel({
+      to: '0x1111111111111111111111111111111111111111',
+      modelId: MODEL_ID,
+      artifactHash: ARTIFACT_HASH,
+      baseModel: BASE_MODEL,
+      weightsCID: 'bafybeigweights',
+      architecture: 'llama-7b',
+      license: 'Apache-2.0',
+      inferenceEndpoint: 'https://infer.example.com',
+      creatorRoyaltyBps: 750,
+    });
+    expect(hash.startsWith('0x')).toBe(true);
+    expect(harness.provider.sentTxs).toHaveLength(1);
+    const tx = harness.provider.sentTxs[0]!;
+    expect(tx.to?.toLowerCase()).toBe(ERC721AI.toLowerCase());
+    const decoded = decodeFunctionData({
+      abi: Erc721AiAbi,
+      data: tx.data!,
+    });
+    expect(decoded.functionName).toBe('mintModel');
+    const args = decoded.args as readonly unknown[];
+    expect((args[0] as string).toLowerCase()).toBe(
+      '0x1111111111111111111111111111111111111111',
+    );
+    expect(args[1]).toBe(MODEL_ID);
+    expect(args[2]).toBe(ARTIFACT_HASH);
+    expect(args[3]).toBe(BASE_MODEL);
+    expect(args[4]).toBe('bafybeigweights');
+    expect(args[8]).toBe(750);
+  });
+
+  it('sends setInferenceEndpoint with the endpoint string', async () => {
+    const harness = makeHarness();
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+      walletClient: harness.walletClient,
+    });
+    await ai.model.setInferenceEndpoint({
+      tokenId: 9n,
+      endpoint: 'https://new-endpoint.example.com/v2',
+    });
+    const tx = harness.provider.sentTxs[0]!;
+    const decoded = decodeFunctionData({
+      abi: Erc721AiAbi,
+      data: tx.data!,
+    });
+    expect(decoded.functionName).toBe('setInferenceEndpoint');
+    expect(decoded.args?.[0]).toBe(9n);
+    expect(decoded.args?.[1]).toBe('https://new-endpoint.example.com/v2');
+  });
+
+  it('sends setAttestationKind with the kind bytes32', async () => {
+    const harness = makeHarness();
+    const ai = createErc721AiClient({
+      contracts: { erc721ai: ERC721AI, metering: METERING },
+      publicClient: harness.publicClient,
+      walletClient: harness.walletClient,
+    });
+    await ai.model.setAttestationKind({ tokenId: 3n, kind: ATTEST_KIND });
+    const tx = harness.provider.sentTxs[0]!;
+    const decoded = decodeFunctionData({
+      abi: Erc721AiAbi,
+      data: tx.data!,
+    });
+    expect(decoded.functionName).toBe('setAttestationKind');
+    expect(decoded.args?.[0]).toBe(3n);
+    expect(decoded.args?.[1]).toBe(ATTEST_KIND);
+  });
+});

--- a/sdk/typescript/tsconfig.build.json
+++ b/sdk/typescript/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "module": "ESNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "test", "examples"]
+}

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "test/**/*", "examples/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/sdk/typescript/vitest.config.ts
+++ b/sdk/typescript/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+    globals: false,
+    testTimeout: 10_000,
+  },
+});


### PR DESCRIPTION
## Summary

Adds `sdk/typescript/` — a viem-based SDK that turns the ERC-721 AI
standard into a consumable client library. Goal: make the tokenised
AI-model + x402 per-inference USDC flow usable in roughly five lines of
code so integrators can mint, price, meter, and collect revenue without
hand-rolling ABI calls.

Three modules plus an aggregator:

- **`ModelModule`** wraps `ERC721AI.sol` — `mintModel`, `modelAsset`,
  `setInferenceEndpoint`, `setAttestationKind`, `royaltyInfo`, `ownerOf`,
  `tokenIdByModelId`, `totalSupply`, plus a client-side `tokenURI` that
  synthesises `ipfs://<weightsCID>` from the on-chain record (the
  reference contract does not store a separate metadata URI).
- **`MeteringModule`** wraps `ERC721AIx402Metering.sol` —
  `registerModel`, `setInferencePrice`, `getInferencePrice`,
  `payForInference`, `payForInferences`, `revenueBalance`,
  `withdrawRevenue`, `totalInferences`, `getModelInfo`,
  `setModelActive`, `usdc`, `protocolFeeBps`.
- **`AttestationModule`** wraps `ERC721AIAttestationHook.sol` —
  `registerAttestation`, `getAttestation`, `verifyAttestation`
  (lightweight on-chain record match, not a re-verification of the
  underlying proof), `attestationVerifier`.
- **`createErc721AiClient({ publicClient, walletClient?, contracts })`**
  aggregator. Attestation is lazy — accessing `ai.attestation` without
  `contracts.attestation` throws a typed `MissingAttestationError`.

## Why

Token-wedge. The Solidity primitives already landed (PR #14 for x402
metering, #17 for the standard). This PR takes the roadmap item
"erc721-ai — x402 per-inference USDC metering" from on-chain bytecode
to something an app developer can import, instantiate, and ship.

## Quality

- Strict TS (`noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`).
- Dual ESM + CJS outputs via `tsconfig.build.json` + a minimal
  `scripts/build-dual.mjs` post-processor. `.d.ts` + sourcemaps emitted.
- Typed error hierarchy rooted at `Erc721AiSdkError`:
  `MissingWalletError`, `InvalidPriceError`, `ModelNotFoundError`,
  `MissingAttestationError`.
- 24 vitest tests across 4 files, backed by an in-memory raw-tx-aware
  EIP-1193 mock provider (`test/helpers.ts`). Zero live chain needed.
- Working `examples/mint-and-meter.ts` end-to-end walkthrough.
- Module-reference + x402 HTTP-402 integration doc in
  `sdk/typescript/README.md`.

## Local verification

```
cd sdk/typescript
npm install
npm run typecheck   # passes
npm test            # 24/24 passing
npm run build       # emits dist/index.mjs + dist/index.cjs + dist/*.d.ts
```

## Files

22 files added under `sdk/typescript/` + one-line pointer added to root
`README.md` + `dist/` entry added to `.gitignore`. No Solidity, tests,
or unrelated files touched.

## Roadmap

Does not close a specific issue. Advances the Q2 "erc721-ai — x402
per-inference USDC metering" roadmap item from on-chain primitives into
a consumable SDK form.