### PR TITLE
docs: fix inconsistent spelling 'tokenised' → 'tokenized' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Design and integration details are documented in `docs/attestation-hook.md`.
 
 ## TypeScript SDK
 
-A viem-based TypeScript SDK for the standard lives in [`sdk/typescript/`](./sdk/typescript/) — it wraps `ERC721AI`, `ERC721AIx402Metering`, and `ERC721AIAttestationHook` behind three modules (`model`, `metering`, `attestation`) so consumers can mint a tokenised model, set an inference price, pay per call, and withdraw revenue in roughly five lines of code. See [`sdk/typescript/README.md`](./sdk/typescript/README.md) for the quickstart.
+A viem-based TypeScript SDK for the standard lives in [`sdk/typescript/`](./sdk/typescript/) — it wraps `ERC721AI`, `ERC721AIx402Metering`, and `ERC721AIAttestationHook` behind three modules (`model`, `metering`, `attestation`) so consumers can mint a tokenized model, set an inference price, pay per call, and withdraw revenue in roughly five lines of code. See [`sdk/typescript/README.md`](./sdk/typescript/README.md) for the quickstart.
 
 ## Links
 


### PR DESCRIPTION
### What
Change `tokenised` to `tokenized` in the TypeScript SDK section of the README.

### Why
The very first line of the README spells it `tokenized` (American English). The SDK paragraph uses the British variant `tokenised`, which is inconsistent. Aligning the spelling keeps the document uniform.

Small, scoped fix from kcolbchain contrib-bot.