### PR TITLE
docs: add real Quick Start setup instructions (closes #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,47 @@ Early development. Looking for contributors! See [open issues](https://github.co
 
 ## Quick Start
 
+### Prerequisites
+
+- [Foundry](https://book.getfoundry.sh/getting-started/installation) (forge, cast, anvil)
+- [Node.js](https://nodejs.org/) >= 18 (for the TypeScript SDK)
+
+### Solidity Contracts
+
 ```bash
 git clone https://github.com/kcolbchain/erc721-ai.git
 cd erc721-ai
-# Setup instructions coming soon
+
+# Install dependencies
+forge install
+
+# Build contracts
+forge build
+
+# Run Solidity tests
+forge test
+```
+
+If you don't have Foundry installed:
+
+```bash
+curl -L https://foundry.paradigm.xyz | bash
+foundryup
+```
+
+### TypeScript SDK
+
+```bash
+cd sdk/typescript
+
+# Install dependencies
+npm install
+
+# Run tests
+npm test
+
+# Build
+npm run build
 ```
 
 ## Contributing


### PR DESCRIPTION
## Issue
Closes #30

## Summary
Replaced the placeholder `# Setup instructions coming soon` with real, tested Quick Start instructions covering Foundry setup (forge install/build/test) and TypeScript SDK setup (npm install/test/build).

## Acceptance criteria
- [x] README Quick Start section has real, tested commands
- [x] Covers: forge install, forge build, forge test
- [x] Covers: TypeScript SDK setup (cd sdk/typescript && npm install && npm test)
- [x] Verified on Linux (Node.js v24.16.0, npm 11.13.0)
- [x] PR references this issue