### PR TITLE
Fix Solidity build for verifier stub

### DIFF
--- a/contracts/extensions/ERC721AIZkVerifierStub.sol
+++ b/contracts/extensions/ERC721AIZkVerifierStub.sol
@@ -48,7 +48,7 @@ contract ERC721AIZkVerifierStub {
         uint256[] calldata publicInputs,
         address verifierContract
     ) external {
-        (bytes32 modelId, bytes32 onChainArtifactHash,,,,,,,,,) = erc721ai.modelAsset(tokenId);
+        (, bytes32 onChainArtifactHash,,,,,,,,) = erc721ai.modelAsset(tokenId);
         if (onChainArtifactHash == bytes32(0)) revert TokenNotFound();
 
         bool verified = IZkVerifier(verifierContract).verifyProof(proof, publicInputs);

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,3 +8,5 @@ optimizer = true
 optimizer_runs = 200
 
 # Install OpenZeppelin for ReentrancyGuard
+
+via_ir = true


### PR DESCRIPTION
Summary:
- Rebased PR #34 onto current upstream `main` after the quickstart docs issue was already resolved by #33.
- Narrowed this PR to the remaining build fix: align `ERC721AIZkVerifierStub` destructuring with the 10-value `modelAsset()` return signature.
- Enabled Foundry `via_ir` for the current contract set.

Adversarial review:
- Removed the redundant README changes so this PR no longer competes with the merged Quick Start docs PR.
- Checked the tuple arity against `ERC721AI.modelAsset()`: the upstream verifier stub destructured 11 slots, while the function returns 10 values.
- Kept the diff to 2 files / 3 insertions / 1 deletion.
- `git diff --check` passes.

Verification note:
- Local container does not have `forge` or `solc`; the Foundry installer URL is blocked by the configured egress policy.
- `npm ci` for the TypeScript SDK did not complete reliably in this container, so no SDK result is claimed here.

This PR is staged as a focused, current-base build fix for maintainer review.