### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  foundry:
+    name: Foundry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Build
+        run: forge build
+
+      - name: Test
+        run: forge test
+
+  typescript-sdk:
+    name: TypeScript SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # erc721-ai
 
+[![CI](https://github.com/kcolbchain/erc721-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/kcolbchain/erc721-ai/actions/workflows/ci.yml)
+
 > Token standard for tokenized fine-tuned AI model weights — ownership, provenance, and tradability
 
 **kcolbchain** — open-source blockchain tools and research since 2015.


### PR DESCRIPTION
## Summary
- Add a GitHub Actions CI workflow for Foundry build/test on pushes to main and pull requests.
- Add a TypeScript SDK job that runs npm ci and npm test.
- Add a README badge linking to the CI workflow status.

## Verification
- Static workflow/readme checks passed locally.
- `cd sdk/typescript && npm ci && npm test` passed: 4 test files, 24 tests.
- `forge build` / `forge test` are configured in CI via `foundry-rs/foundry-toolchain@v1`; local environment did not have Foundry preinstalled.

Closes #31
/claim #31
