### PR TITLE
Add GitHub Actions CI for Foundry and SDK tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  foundry:
+    name: Foundry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Build contracts
+        run: forge build
+
+      - name: Run contract tests
+        run: forge test
+
+  typescript-sdk:
+    name: TypeScript SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run SDK tests
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           version: stable
 
+      - name: Install contract dependencies
+        run: forge install --no-git foundry-rs/forge-std OpenZeppelin/openzeppelin-contracts
+
       - name: Build contracts
         run: forge build
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # erc721-ai
 
+[![CI](https://github.com/kcolbchain/erc721-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/kcolbchain/erc721-ai/actions/workflows/ci.yml)
+
 > Token standard for tokenized fine-tuned AI model weights — ownership, provenance, and tradability
 
 **kcolbchain** — open-source blockchain tools and research since 2015.

--- a/contracts/extensions/ERC721AIZkVerifierStub.sol
+++ b/contracts/extensions/ERC721AIZkVerifierStub.sol
@@ -48,7 +48,7 @@ contract ERC721AIZkVerifierStub {
         uint256[] calldata publicInputs,
         address verifierContract
     ) external {
-        (bytes32 modelId, bytes32 onChainArtifactHash,,,,,,,,,) = erc721ai.modelAsset(tokenId);
+        (, bytes32 onChainArtifactHash,,,,,,,,) = erc721ai.modelAsset(tokenId);
         if (onChainArtifactHash == bytes32(0)) revert TokenNotFound();
 
         bool verified = IZkVerifier(verifierContract).verifyProof(proof, publicInputs);

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,5 +6,6 @@ libs = ["lib"]
 solc_version = "0.8.24"
 optimizer = true
 optimizer_runs = 200
+via_ir = true
 
 # Install OpenZeppelin for ReentrancyGuard


### PR DESCRIPTION
## Summary
- Add a GitHub Actions CI workflow for Foundry contract checks.
- Install Foundry dependencies in CI before running `forge build` and `forge test`.
- Add the TypeScript SDK test job with `npm ci` and `npm test`.
- Add a README badge linking to the CI workflow.
- Fix the zk verifier stub tuple destructuring so the existing Foundry suite compiles.
- Enable `via_ir` for the current Solidity test suite.

Closes #31

## Validation
- `git diff --check` passes.
- `forge build` passes locally.
- `forge test` passes locally: 34 tests.