### PR TITLE
Add GitHub Actions CI for forge build + forge test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  forge:
+    name: Foundry Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run forge build
+        run: forge build
+
+      - name: Run forge test
+        run: forge test
+
+  sdk:
+    name: TypeScript SDK Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # erc721-ai
 
+[![CI](https://github.com/kcolbchain/erc721-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/kcolbchain/erc721-ai/actions/workflows/ci.yml)
+
 > Token standard for tokenized fine-tuned AI model weights — ownership, provenance, and tradability
 
 **kcolbchain** — open-source blockchain tools and research since 2015.


### PR DESCRIPTION
/claim #31 $35

This PR adds a GitHub Actions CI workflow that:

- Triggers on push to main and pull requests
- Runs `forge build` and `forge test` using the Foundry toolchain
- Runs TypeScript SDK tests (bonus)
- Adds a CI status badge to the README

Closes #31