### PR TITLE
feat: add GitHub Actions CI for forge build + forge test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  solidity:
+    name: Forge build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+          cache: false
+
+      - name: Build contracts
+        run: forge build
+
+      - name: Run Solidity tests
+        run: forge test
+
+  typescript:
+    name: TypeScript SDK tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run SDK tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ## Status
 
+[![CI](https://github.com/kcolbchain/erc721-ai/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/kcolbchain/erc721-ai/actions/workflows/ci.yml)
+
 Early development. Looking for contributors! See [open issues](https://github.com/kcolbchain/erc721-ai/issues) for ways to help.
 
 ## Quick Start


### PR DESCRIPTION
Fixes #31

- Adds a CI workflow that runs on push to main and pull requests
- Verifies the Solidity contracts with `forge build` and `forge test`
- Verifies the TypeScript SDK with `npm ci` and `npm test`
- Adds a README badge linked to the workflow status

Validated locally with:
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'
- npm ci
- npm test
- npm run build