### PR TITLE
docs: clarify quickstart verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,31 @@ npm test
 npm run build
 ```
 
+On Windows PowerShell, use `npm.cmd` if script execution policy blocks the
+`npm.ps1` shim:
+
+```powershell
+cd sdk\typescript
+npm.cmd install
+npm.cmd test
+npm.cmd run build
+```
+
+### Verification Notes
+
+The TypeScript SDK quickstart was verified on Windows PowerShell with Node
+v24.16.0 and npm v11.13.0:
+
+- `cd sdk\typescript`
+- `npm.cmd install`
+- `npm.cmd test` (24 tests passed)
+- `npm.cmd run build`
+
+The Solidity commands above require Foundry's `forge` to be installed and
+available on `PATH`. On Windows, Foundry's installer should be run from Git Bash
+or WSL; after `forge --version` succeeds, run `forge install`, `forge build`,
+and `forge test` from the repository root.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started. Issues tagged `good-first-issue` are great entry points.


### PR DESCRIPTION
## Summary
- add Windows PowerShell `npm.cmd` equivalents for the TypeScript SDK quickstart
- add a verification note with the Node/npm versions and SDK commands that were run
- clarify that Foundry's `forge` commands require `forge` on `PATH`, and that Windows users should install Foundry from Git Bash or WSL before running `forge install`, `forge build`, and `forge test`

Refs #30

## Validation
- `npm.cmd install` in `sdk/typescript`
- `npm.cmd test` in `sdk/typescript` (24 tests passed)
- `npm.cmd run build` in `sdk/typescript`
- `git diff --check`

Not run locally:
- `forge install`
- `forge build`
- `forge test`

Reason: this Windows PowerShell environment does not have Foundry installed (`forge` is not on `PATH`). The README now calls out the Foundry prerequisite and the Windows Git Bash/WSL install requirement.
