### PR TITLE
L1: Add GitHub Actions CI for forge build + forge test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run Forge build
+        run: |
+          forge --version
+          forge build --sizes
+
+      - name: Run Forge tests
+        run: |
+          forge test -vvv
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run SDK Tests
+        run: |
+          cd sdk/typescript
+          npm ci
+          npm test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > Token standard for tokenized fine-tuned AI model weights — ownership, provenance, and tradability
 
+[![CI](https://github.com/kcolbchain/erc721-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/kcolbchain/erc721-ai/actions/workflows/ci.yml)
+
 **kcolbchain** — open-source blockchain tools and research since 2015.
 
 ## Status


### PR DESCRIPTION
Resolves #31. Added a GitHub Actions workflow that installs Foundry, runs `forge build` and `forge test`, and also sets up Node.js to run the TypeScript SDK tests. Also added a CI badge to the README.