### PR TITLE
docs: linkify attestation-hook.md reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This repo also includes a pluggable contract-level attestation hook for verifiab
 - `contracts/mocks/MockTrainingAttestationVerifier.sol`
 - `contracts/ERC721AIAttestationHook.sol`
 
-Design and integration details are documented in `docs/attestation-hook.md`.
+Design and integration details are documented in [`docs/attestation-hook.md`](docs/attestation-hook.md).
 
 ## TypeScript SDK
 


### PR DESCRIPTION
### What
Turns the plain-text `docs/attestation-hook.md` path in the Attestation Hook section into a clickable Markdown hyperlink.

### Why
Every other document reference in the README (e.g. `docs/spec-erc721-ai.md`, `sdk/typescript/README.md`) is already a hyperlink. This one was left as a bare code span, making it harder to navigate directly from the rendered README.

Small, scoped fix from kcolbchain contrib-bot.