### PR TITLE
test: strengthen coverage on attestation/ZK and x402 metering paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ __pycache__/
 .env
 .venv/
 venv/
+
+# Foundry deps are installed in CI via `forge install --no-git`; keep local install artifacts out of git
+lib/
+foundry.lock
+.gitmodules

--- a/test/ERC721AIZkVerifierStub.t.sol
+++ b/test/ERC721AIZkVerifierStub.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/ERC721AI.sol";
+import "../contracts/extensions/ERC721AIZkVerifierStub.sol";
+import "./mocks/MockZkVerifier.sol";
+
+contract ERC721AIZkVerifierStubTest is Test {
+    ERC721AI internal erc721ai;
+    ERC721AIZkVerifierStub internal stub;
+    MockZkVerifier internal verifier;
+
+    address internal admin;
+    address internal creator;
+    address internal alice;
+
+    bytes32 internal constant MODEL_ID = keccak256("model-zk");
+    bytes32 internal constant ARTIFACT_HASH = keccak256("weights-zk");
+
+    event ProofSubmitted(uint256 indexed tokenId, bytes32 indexed proofHash, bool passed);
+
+    function setUp() public {
+        admin = makeAddr("admin");
+        creator = makeAddr("creator");
+        alice = makeAddr("alice");
+
+        erc721ai = new ERC721AI("ERC-721 AI", "AI721");
+        stub = new ERC721AIZkVerifierStub(address(erc721ai), admin);
+        verifier = new MockZkVerifier();
+    }
+
+    function _mint() internal returns (uint256 tokenId) {
+        vm.prank(creator);
+        tokenId = erc721ai.mintModel(
+            alice, MODEL_ID, ARTIFACT_HASH, bytes32(0), "ipfs://w", "arch", "MIT", "https://inf", 0
+        );
+    }
+
+    function _proof() internal pure returns (uint256[] memory proof, uint256[] memory inputs) {
+        proof = new uint256[](2);
+        proof[0] = 1;
+        proof[1] = 2;
+        inputs = new uint256[](1);
+        inputs[0] = uint256(ARTIFACT_HASH);
+    }
+
+    // ── Deployment ──────────────────────────────────────────────────────
+
+    function test_Deployment() public view {
+        assertEq(address(stub.erc721ai()), address(erc721ai));
+        assertEq(stub.admin(), admin);
+    }
+
+    // ── submitProof: happy path ─────────────────────────────────────────
+
+    function test_SubmitProofRecordsPassingVerification() public {
+        uint256 tokenId = _mint();
+        (uint256[] memory proof, uint256[] memory inputs) = _proof();
+        bytes32 expectedProofHash = keccak256(abi.encode(proof, inputs));
+
+        vm.expectEmit(true, true, false, true);
+        emit ProofSubmitted(tokenId, expectedProofHash, true);
+        stub.submitProof(tokenId, ARTIFACT_HASH, proof, inputs, address(verifier));
+
+        assertEq(stub.getTokenProofHash(tokenId), expectedProofHash);
+
+        ERC721AIZkVerifierStub.VerificationRecord memory rec = stub.getVerificationRecord(expectedProofHash);
+        assertEq(rec.tokenId, tokenId);
+        // The stub binds the record to the ON-CHAIN artifact hash, not the
+        // caller-supplied one — this is the provenance anchor.
+        assertEq(rec.artifactHash, ARTIFACT_HASH);
+        assertEq(rec.proofHash, expectedProofHash);
+        assertTrue(rec.passed);
+        assertGt(rec.verifiedAt, 0);
+    }
+
+    function test_SubmitProofRecordsFailingVerification() public {
+        uint256 tokenId = _mint();
+        verifier.setResult(false);
+        (uint256[] memory proof, uint256[] memory inputs) = _proof();
+        bytes32 expectedProofHash = keccak256(abi.encode(proof, inputs));
+
+        vm.expectEmit(true, true, false, true);
+        emit ProofSubmitted(tokenId, expectedProofHash, false);
+        stub.submitProof(tokenId, ARTIFACT_HASH, proof, inputs, address(verifier));
+
+        ERC721AIZkVerifierStub.VerificationRecord memory rec = stub.getVerificationRecord(expectedProofHash);
+        assertFalse(rec.passed);
+        // Even a failing proof is recorded for auditability.
+        assertEq(rec.tokenId, tokenId);
+        assertGt(rec.verifiedAt, 0);
+    }
+
+    // ── submitProof: binds to on-chain artifact hash ────────────────────
+
+    function test_RecordUsesOnChainArtifactHashNotCallerSupplied() public {
+        uint256 tokenId = _mint();
+        (uint256[] memory proof, uint256[] memory inputs) = _proof();
+        bytes32 lie = keccak256("not-the-real-artifact");
+
+        // Caller passes a bogus artifactHash; the stub ignores it and stores
+        // the authoritative on-chain value.
+        stub.submitProof(tokenId, lie, proof, inputs, address(verifier));
+
+        bytes32 proofHash = keccak256(abi.encode(proof, inputs));
+        ERC721AIZkVerifierStub.VerificationRecord memory rec = stub.getVerificationRecord(proofHash);
+        assertEq(rec.artifactHash, ARTIFACT_HASH);
+        assertTrue(rec.artifactHash != lie);
+    }
+
+    // ── submitProof: reverts ────────────────────────────────────────────
+
+    function test_RevertWhenTokenNotFound() public {
+        (uint256[] memory proof, uint256[] memory inputs) = _proof();
+        // modelAsset reverts with TokenDoesNotExist for a nonexistent token.
+        vm.expectRevert(ERC721AI.TokenDoesNotExist.selector);
+        stub.submitProof(999, ARTIFACT_HASH, proof, inputs, address(verifier));
+    }
+
+    // ── proofHash determinism / mutation ────────────────────────────────
+
+    function test_DifferentInputsProduceDifferentProofHash() public {
+        uint256 tokenId = _mint();
+        (uint256[] memory proof, uint256[] memory inputs) = _proof();
+        stub.submitProof(tokenId, ARTIFACT_HASH, proof, inputs, address(verifier));
+        bytes32 firstHash = stub.getTokenProofHash(tokenId);
+
+        // Mutate a public input — the recorded proofHash for the token must change.
+        inputs[0] = uint256(keccak256("different-input"));
+        stub.submitProof(tokenId, ARTIFACT_HASH, proof, inputs, address(verifier));
+        bytes32 secondHash = stub.getTokenProofHash(tokenId);
+
+        assertTrue(firstHash != secondHash);
+        // The original record is still retained (keyed by its own proofHash).
+        assertEq(stub.getVerificationRecord(firstHash).tokenId, tokenId);
+        assertEq(stub.getVerificationRecord(secondHash).tokenId, tokenId);
+    }
+
+    function test_AnyoneMaySubmitProof() public {
+        uint256 tokenId = _mint();
+        (uint256[] memory proof, uint256[] memory inputs) = _proof();
+        vm.prank(makeAddr("randomRelayer"));
+        stub.submitProof(tokenId, ARTIFACT_HASH, proof, inputs, address(verifier));
+        assertTrue(stub.getVerificationRecord(keccak256(abi.encode(proof, inputs))).passed);
+    }
+
+    function test_UnsetTokenProofHashIsZero() public {
+        uint256 tokenId = _mint();
+        assertEq(stub.getTokenProofHash(tokenId), bytes32(0));
+    }
+}

--- a/test/ERC721AIx402Metering.t.sol
+++ b/test/ERC721AIx402Metering.t.sol
@@ -1,0 +1,457 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/ERC721AIx402Metering.sol";
+import "./mocks/MockUSDC.sol";
+import "./mocks/RevertingUSDC.sol";
+
+contract ERC721AIx402MeteringTest is Test {
+    ERC721AIx402Metering internal metering;
+    MockUSDC internal usdc;
+
+    address internal admin;
+    address internal feeRecipient;
+    address internal modelOwner;
+    address internal caller;
+    address internal stranger;
+
+    uint16 internal constant FEE_BPS = 250; // 2.5%
+    uint256 internal constant TOKEN_ID = 42;
+    uint128 internal constant PRICE = 1_000_000; // 1 USDC (6 decimals)
+
+    event ModelRegistered(uint256 indexed tokenId, address indexed owner, uint128 price);
+    event InferencePriceUpdated(uint256 indexed tokenId, uint128 oldPrice, uint128 newPrice);
+    event InferencePaid(uint256 indexed tokenId, address indexed caller, uint128 amount, uint256 inferenceCount);
+    event RevenueWithdrawn(address indexed owner, uint256 amount);
+    event ProtocolFeeUpdated(uint16 oldBps, uint16 newBps);
+
+    function setUp() public {
+        admin = makeAddr("admin");
+        feeRecipient = makeAddr("feeRecipient");
+        modelOwner = makeAddr("modelOwner");
+        caller = makeAddr("caller");
+        stranger = makeAddr("stranger");
+
+        usdc = new MockUSDC();
+        metering = new ERC721AIx402Metering(address(usdc), admin, feeRecipient, FEE_BPS);
+
+        // Fund and approve the inference caller generously.
+        usdc.mint(caller, 1_000_000_000); // 1,000 USDC
+        vm.prank(caller);
+        usdc.approve(address(metering), type(uint256).max);
+    }
+
+    function _register() internal {
+        vm.prank(modelOwner);
+        metering.registerModel(TOKEN_ID, PRICE);
+    }
+
+    // ── Constructor ─────────────────────────────────────────────────────
+
+    function test_ConstructorStoresConfig() public view {
+        assertEq(address(metering.usdc()), address(usdc));
+        assertEq(metering.admin(), admin);
+        assertEq(metering.protocolFeeRecipient(), feeRecipient);
+        assertEq(metering.protocolFeeBps(), FEE_BPS);
+    }
+
+    function test_RevertWhenConstructorFeeTooHigh() public {
+        vm.expectRevert(ERC721AIx402Metering.FeeTooHigh.selector);
+        new ERC721AIx402Metering(address(usdc), admin, feeRecipient, 1001);
+    }
+
+    function test_ConstructorAcceptsMaxFee() public {
+        ERC721AIx402Metering m = new ERC721AIx402Metering(address(usdc), admin, feeRecipient, 1000);
+        assertEq(m.protocolFeeBps(), 1000);
+    }
+
+    // ── Registration ────────────────────────────────────────────────────
+
+    function test_RegisterModelStoresOwnerAndPrice() public {
+        vm.expectEmit(true, true, false, true);
+        emit ModelRegistered(TOKEN_ID, modelOwner, PRICE);
+        _register();
+
+        (address owner, uint128 price, bool active, uint256 inferences) = metering.getModelInfo(TOKEN_ID);
+        assertEq(owner, modelOwner);
+        assertEq(price, PRICE);
+        assertTrue(active);
+        assertEq(inferences, 0);
+    }
+
+    function test_RevertWhenRegisterDuplicate() public {
+        _register();
+        vm.prank(modelOwner);
+        vm.expectRevert(ERC721AIx402Metering.ModelAlreadyRegistered.selector);
+        metering.registerModel(TOKEN_ID, PRICE);
+    }
+
+    function test_RevertWhenRegisterDuplicateByDifferentOwner() public {
+        _register();
+        vm.prank(stranger);
+        vm.expectRevert(ERC721AIx402Metering.ModelAlreadyRegistered.selector);
+        metering.registerModel(TOKEN_ID, PRICE);
+    }
+
+    function test_RevertWhenRegisterZeroPrice() public {
+        vm.prank(modelOwner);
+        vm.expectRevert(ERC721AIx402Metering.ZeroPrice.selector);
+        metering.registerModel(TOKEN_ID, 0);
+    }
+
+    // ── Price mutation ──────────────────────────────────────────────────
+
+    function test_OwnerCanUpdatePrice() public {
+        _register();
+        uint128 newPrice = 2_000_000;
+        vm.expectEmit(true, false, false, true);
+        emit InferencePriceUpdated(TOKEN_ID, PRICE, newPrice);
+        vm.prank(modelOwner);
+        metering.setInferencePrice(TOKEN_ID, newPrice);
+        assertEq(metering.getInferencePrice(TOKEN_ID), newPrice);
+    }
+
+    function test_RevertWhenNonOwnerUpdatesPrice() public {
+        _register();
+        vm.prank(stranger);
+        vm.expectRevert(ERC721AIx402Metering.NotModelOwner.selector);
+        metering.setInferencePrice(TOKEN_ID, 2_000_000);
+    }
+
+    function test_RevertWhenUpdatePriceToZero() public {
+        _register();
+        vm.prank(modelOwner);
+        vm.expectRevert(ERC721AIx402Metering.ZeroPrice.selector);
+        metering.setInferencePrice(TOKEN_ID, 0);
+    }
+
+    function test_RevertWhenSetPriceOnUnregisteredModel() public {
+        // owner of an unregistered model is address(0); msg.sender never matches.
+        vm.prank(modelOwner);
+        vm.expectRevert(ERC721AIx402Metering.NotModelOwner.selector);
+        metering.setInferencePrice(999, PRICE);
+    }
+
+    // ── Active toggle ───────────────────────────────────────────────────
+
+    function test_OwnerCanDeactivateAndReactivate() public {
+        _register();
+        vm.prank(modelOwner);
+        metering.setModelActive(TOKEN_ID, false);
+        (,, bool active,) = metering.getModelInfo(TOKEN_ID);
+        assertFalse(active);
+
+        vm.prank(modelOwner);
+        metering.setModelActive(TOKEN_ID, true);
+        (,, active,) = metering.getModelInfo(TOKEN_ID);
+        assertTrue(active);
+    }
+
+    function test_RevertWhenNonOwnerTogglesActive() public {
+        _register();
+        vm.prank(stranger);
+        vm.expectRevert(ERC721AIx402Metering.NotModelOwner.selector);
+        metering.setModelActive(TOKEN_ID, false);
+    }
+
+    // ── Pay / settle: single ────────────────────────────────────────────
+
+    function test_PayForInferenceSplitsRevenue() public {
+        _register();
+
+        uint128 expectedFee = uint128(uint256(PRICE) * FEE_BPS / 10000); // 25,000
+        uint128 expectedOwnerShare = PRICE - expectedFee; // 975,000
+
+        vm.expectEmit(true, true, false, true);
+        emit InferencePaid(TOKEN_ID, caller, PRICE, 1);
+        vm.prank(caller);
+        metering.payForInference(TOKEN_ID);
+
+        assertEq(metering.revenueBalance(modelOwner), expectedOwnerShare);
+        assertEq(metering.revenueBalance(feeRecipient), expectedFee);
+        assertEq(metering.totalInferences(TOKEN_ID), 1);
+        // Contract custody equals total collected until withdrawal.
+        assertEq(usdc.balanceOf(address(metering)), PRICE);
+    }
+
+    function test_PayForInferenceAccumulatesAcrossCalls() public {
+        _register();
+        vm.startPrank(caller);
+        metering.payForInference(TOKEN_ID);
+        metering.payForInference(TOKEN_ID);
+        metering.payForInference(TOKEN_ID);
+        vm.stopPrank();
+
+        uint128 fee = uint128(uint256(PRICE) * FEE_BPS / 10000);
+        assertEq(metering.totalInferences(TOKEN_ID), 3);
+        assertEq(metering.revenueBalance(modelOwner), uint256(PRICE - fee) * 3);
+        assertEq(metering.revenueBalance(feeRecipient), uint256(fee) * 3);
+    }
+
+    function test_RevertWhenPayInactiveModel() public {
+        _register();
+        vm.prank(modelOwner);
+        metering.setModelActive(TOKEN_ID, false);
+
+        vm.prank(caller);
+        vm.expectRevert(ERC721AIx402Metering.ModelNotActive.selector);
+        metering.payForInference(TOKEN_ID);
+    }
+
+    function test_RevertWhenPayUnregisteredModel() public {
+        // Unregistered model defaults to active == false.
+        vm.prank(caller);
+        vm.expectRevert(ERC721AIx402Metering.ModelNotActive.selector);
+        metering.payForInference(123456);
+    }
+
+    function test_RevertWhenCallerHasNotApproved() public {
+        _register();
+        address poor = makeAddr("poor");
+        usdc.mint(poor, PRICE);
+        // No approval granted.
+        vm.prank(poor);
+        vm.expectRevert();
+        metering.payForInference(TOKEN_ID);
+    }
+
+    function test_RevertWhenCallerHasInsufficientBalance() public {
+        _register();
+        address broke = makeAddr("broke");
+        vm.prank(broke);
+        usdc.approve(address(metering), type(uint256).max);
+        vm.prank(broke);
+        vm.expectRevert();
+        metering.payForInference(TOKEN_ID);
+    }
+
+    function test_NoFeeWhenZeroFeeBps() public {
+        ERC721AIx402Metering m = new ERC721AIx402Metering(address(usdc), admin, feeRecipient, 0);
+        vm.prank(modelOwner);
+        m.registerModel(TOKEN_ID, PRICE);
+
+        vm.prank(caller);
+        usdc.approve(address(m), type(uint256).max);
+        vm.prank(caller);
+        m.payForInference(TOKEN_ID);
+
+        assertEq(m.revenueBalance(modelOwner), PRICE);
+        assertEq(m.revenueBalance(feeRecipient), 0);
+    }
+
+    // ── Pay / settle: batch ─────────────────────────────────────────────
+
+    function test_PayForInferencesBatchSplitsRevenue() public {
+        _register();
+        uint256 count = 10;
+
+        uint256 totalPrice = uint256(PRICE) * count;
+        uint256 fee = totalPrice * FEE_BPS / 10000;
+        uint256 ownerShare = totalPrice - fee;
+
+        vm.expectEmit(true, true, false, true);
+        emit InferencePaid(TOKEN_ID, caller, uint128(totalPrice), count);
+        vm.prank(caller);
+        metering.payForInferences(TOKEN_ID, count);
+
+        assertEq(metering.totalInferences(TOKEN_ID), count);
+        assertEq(metering.revenueBalance(modelOwner), ownerShare);
+        assertEq(metering.revenueBalance(feeRecipient), fee);
+        assertEq(usdc.balanceOf(address(metering)), totalPrice);
+    }
+
+    function test_RevertWhenBatchPayInactiveModel() public {
+        _register();
+        vm.prank(modelOwner);
+        metering.setModelActive(TOKEN_ID, false);
+        vm.prank(caller);
+        vm.expectRevert(ERC721AIx402Metering.ModelNotActive.selector);
+        metering.payForInferences(TOKEN_ID, 5);
+    }
+
+    function test_BatchOfZeroChargesNothingButCountsZero() public {
+        _register();
+        vm.prank(caller);
+        metering.payForInferences(TOKEN_ID, 0);
+        assertEq(metering.totalInferences(TOKEN_ID), 0);
+        assertEq(metering.revenueBalance(modelOwner), 0);
+        assertEq(usdc.balanceOf(address(metering)), 0);
+    }
+
+    function test_SingleAndBatchProduceConsistentAccounting() public {
+        _register();
+        // 5 singles
+        vm.startPrank(caller);
+        for (uint256 i = 0; i < 5; i++) {
+            metering.payForInference(TOKEN_ID);
+        }
+        // then a batch of 5
+        metering.payForInferences(TOKEN_ID, 5);
+        vm.stopPrank();
+
+        assertEq(metering.totalInferences(TOKEN_ID), 10);
+        // Per-unit fee on single = floor(PRICE*bps/10000); batch fee computed on the sum.
+        // For PRICE divisible such that there is no rounding, the two must add up exactly.
+        uint256 singleFeeEach = uint256(PRICE) * FEE_BPS / 10000;
+        uint256 batchFee = (uint256(PRICE) * 5) * FEE_BPS / 10000;
+        uint256 expectedFee = singleFeeEach * 5 + batchFee;
+        assertEq(metering.revenueBalance(feeRecipient), expectedFee);
+        assertEq(metering.revenueBalance(modelOwner), uint256(PRICE) * 10 - expectedFee);
+    }
+
+    // ── Withdrawals ─────────────────────────────────────────────────────
+
+    function test_WithdrawTransfersAndResets() public {
+        _register();
+        vm.prank(caller);
+        metering.payForInference(TOKEN_ID);
+
+        uint128 fee = uint128(uint256(PRICE) * FEE_BPS / 10000);
+        uint256 ownerShare = PRICE - fee;
+
+        vm.expectEmit(true, false, false, true);
+        emit RevenueWithdrawn(modelOwner, ownerShare);
+        vm.prank(modelOwner);
+        metering.withdrawRevenue();
+
+        assertEq(usdc.balanceOf(modelOwner), ownerShare);
+        assertEq(metering.revenueBalance(modelOwner), 0);
+        // Fee recipient share remains in custody.
+        assertEq(usdc.balanceOf(address(metering)), fee);
+    }
+
+    function test_FeeRecipientCanWithdraw() public {
+        _register();
+        vm.prank(caller);
+        metering.payForInference(TOKEN_ID);
+
+        uint128 fee = uint128(uint256(PRICE) * FEE_BPS / 10000);
+        vm.prank(feeRecipient);
+        metering.withdrawRevenue();
+        assertEq(usdc.balanceOf(feeRecipient), fee);
+        assertEq(metering.revenueBalance(feeRecipient), 0);
+    }
+
+    function test_WithdrawWithZeroBalanceIsNoOp() public {
+        // No revert, no transfer, no event side effects.
+        uint256 before = usdc.balanceOf(stranger);
+        vm.prank(stranger);
+        metering.withdrawRevenue();
+        assertEq(usdc.balanceOf(stranger), before);
+    }
+
+    function test_DoubleWithdrawDrainsOnce() public {
+        _register();
+        vm.prank(caller);
+        metering.payForInference(TOKEN_ID);
+
+        uint256 ownerShare = PRICE - uint256(PRICE) * FEE_BPS / 10000;
+        vm.prank(modelOwner);
+        metering.withdrawRevenue();
+        // Second withdraw is a no-op.
+        vm.prank(modelOwner);
+        metering.withdrawRevenue();
+        assertEq(usdc.balanceOf(modelOwner), ownerShare);
+    }
+
+    function test_SettlementFailurePropagates() public {
+        // Use a token whose transferFrom can be forced to fail; SafeERC20 must revert,
+        // so no revenue is credited and no inference is counted.
+        RevertingUSDC bad = new RevertingUSDC();
+        ERC721AIx402Metering m = new ERC721AIx402Metering(address(bad), admin, feeRecipient, FEE_BPS);
+        vm.prank(modelOwner);
+        m.registerModel(TOKEN_ID, PRICE);
+
+        bad.mint(caller, PRICE);
+        vm.prank(caller);
+        bad.approve(address(m), type(uint256).max);
+        bad.setFailTransfers(true);
+
+        vm.prank(caller);
+        vm.expectRevert(); // SafeERC20: SafeERC20FailedOperation
+        m.payForInference(TOKEN_ID);
+
+        assertEq(m.totalInferences(TOKEN_ID), 0);
+        assertEq(m.revenueBalance(modelOwner), 0);
+    }
+
+    // ── Admin: protocol fee ─────────────────────────────────────────────
+
+    function test_AdminCanUpdateFee() public {
+        vm.expectEmit(false, false, false, true);
+        emit ProtocolFeeUpdated(FEE_BPS, 500);
+        vm.prank(admin);
+        metering.setProtocolFee(500);
+        assertEq(metering.protocolFeeBps(), 500);
+    }
+
+    function test_RevertWhenNonAdminUpdatesFee() public {
+        vm.prank(stranger);
+        vm.expectRevert(ERC721AIx402Metering.NotModelOwner.selector); // contract reuses this error for admin gate
+        metering.setProtocolFee(500);
+    }
+
+    function test_RevertWhenAdminSetsFeeTooHigh() public {
+        vm.prank(admin);
+        vm.expectRevert(ERC721AIx402Metering.FeeTooHigh.selector);
+        metering.setProtocolFee(1001);
+    }
+
+    function test_FeeUpdateAffectsSubsequentPayments() public {
+        _register();
+        vm.prank(admin);
+        metering.setProtocolFee(1000); // 10%
+
+        vm.prank(caller);
+        metering.payForInference(TOKEN_ID);
+
+        uint256 fee = uint256(PRICE) * 1000 / 10000;
+        assertEq(metering.revenueBalance(feeRecipient), fee);
+        assertEq(metering.revenueBalance(modelOwner), PRICE - fee);
+    }
+
+    // ── Fuzz: fee-split invariants ──────────────────────────────────────
+
+    function testFuzz_FeeSplitConservesValue(uint128 price, uint16 feeBps) public {
+        price = uint128(bound(price, 1, type(uint96).max)); // keep custody well within balance
+        feeBps = uint16(bound(feeBps, 0, 1000));
+
+        ERC721AIx402Metering m = new ERC721AIx402Metering(address(usdc), admin, feeRecipient, feeBps);
+        vm.prank(modelOwner);
+        m.registerModel(TOKEN_ID, price);
+
+        usdc.mint(caller, price);
+        vm.prank(caller);
+        usdc.approve(address(m), type(uint256).max);
+        vm.prank(caller);
+        m.payForInference(TOKEN_ID);
+
+        uint256 ownerBal = m.revenueBalance(modelOwner);
+        uint256 feeBal = m.revenueBalance(feeRecipient);
+        // No value is created or destroyed: owner + fee == price exactly.
+        assertEq(ownerBal + feeBal, price);
+        // Fee never exceeds the configured ceiling.
+        assertLe(feeBal, uint256(price) * feeBps / 10000);
+    }
+
+    function testFuzz_BatchAccounting(uint128 price, uint8 count) public {
+        price = uint128(bound(price, 1, 1e15));
+        uint256 c = bound(count, 1, 100);
+
+        ERC721AIx402Metering m = new ERC721AIx402Metering(address(usdc), admin, feeRecipient, FEE_BPS);
+        vm.prank(modelOwner);
+        m.registerModel(TOKEN_ID, price);
+
+        uint256 total = uint256(price) * c;
+        usdc.mint(caller, total);
+        vm.prank(caller);
+        usdc.approve(address(m), type(uint256).max);
+        vm.prank(caller);
+        m.payForInferences(TOKEN_ID, c);
+
+        assertEq(m.totalInferences(TOKEN_ID), c);
+        assertEq(m.revenueBalance(modelOwner) + m.revenueBalance(feeRecipient), total);
+        assertEq(usdc.balanceOf(address(m)), total);
+    }
+}

--- a/test/ProvenanceLineage.t.sol
+++ b/test/ProvenanceLineage.t.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/ERC721AI.sol";
+import "../contracts/ERC721AIAttestationHook.sol";
+import "../contracts/extensions/ERC721AIZkVerifierStub.sol";
+import "../contracts/mocks/MockTrainingAttestationVerifier.sol";
+import "./mocks/MockZkVerifier.sol";
+
+/// @notice End-to-end provenance: a multi-hop model lineage (base → fine-tune →
+///         distill) where each derived token references its parent's modelId,
+///         carries a verified training attestation, and is anchored by a ZK
+///         proof bound to its on-chain artifact hash. Exercises the seam
+///         between ERC721AI, the attestation hook, and the ZK verifier stub.
+contract ProvenanceLineageTest is Test {
+    ERC721AI internal nft;
+    ERC721AIAttestationHook internal hook;
+    ERC721AIZkVerifierStub internal stub;
+    MockTrainingAttestationVerifier internal attVerifier;
+    MockZkVerifier internal zkVerifier;
+
+    address internal hookOwner;
+    address internal stubAdmin;
+    address internal creator;
+    address internal holder;
+
+    bytes32 internal constant KIND_ZK_TEE = keccak256("zk-tee");
+
+    bytes32 internal constant BASE_ID = keccak256("llama-base");
+    bytes32 internal constant FT_ID = keccak256("llama-finetune");
+    bytes32 internal constant DISTILL_ID = keccak256("llama-distill");
+
+    bytes32 internal constant BASE_ART = keccak256("base-weights");
+    bytes32 internal constant FT_ART = keccak256("finetune-weights");
+    bytes32 internal constant DISTILL_ART = keccak256("distill-weights");
+
+    function setUp() public {
+        hookOwner = makeAddr("hookOwner");
+        stubAdmin = makeAddr("stubAdmin");
+        creator = makeAddr("creator");
+        holder = makeAddr("holder");
+
+        nft = new ERC721AI("ERC-721 AI", "AI721");
+        hook = new ERC721AIAttestationHook(hookOwner);
+        stub = new ERC721AIZkVerifierStub(address(nft), stubAdmin);
+        attVerifier = new MockTrainingAttestationVerifier();
+        zkVerifier = new MockZkVerifier();
+
+        vm.prank(hookOwner);
+        hook.setAttestationVerifier(KIND_ZK_TEE, address(attVerifier));
+    }
+
+    function _mint(bytes32 modelId, bytes32 artifact, bytes32 base) internal returns (uint256 id) {
+        vm.prank(creator);
+        id = nft.mintModel(holder, modelId, artifact, base, "ipfs://w", "arch", "MIT", "https://inf", 300);
+    }
+
+    function test_ThreeHopLineageWithAttestationAndZkAnchor() public {
+        // Hop 0: base model, no parent.
+        uint256 baseTok = _mint(BASE_ID, BASE_ART, bytes32(0));
+        // Hop 1: fine-tune references the base modelId.
+        uint256 ftTok = _mint(FT_ID, FT_ART, BASE_ID);
+        // Hop 2: distillation references the fine-tune modelId.
+        uint256 distillTok = _mint(DISTILL_ID, DISTILL_ART, FT_ID);
+
+        // ── Lineage links resolve parent → child via tokenIdByModelId. ──
+        (,, bytes32 ftBase,,,,,,,) = nft.modelAsset(ftTok);
+        (,, bytes32 distillBase,,,,,,,) = nft.modelAsset(distillTok);
+        assertEq(ftBase, BASE_ID);
+        assertEq(distillBase, FT_ID);
+        assertEq(nft.tokenIdByModelId(ftBase), baseTok);
+        assertEq(nft.tokenIdByModelId(distillBase), ftTok);
+
+        // Walk the chain from the leaf back to the root.
+        uint256 cursor = distillTok;
+        uint256 hops;
+        while (true) {
+            (, , bytes32 parentModelId,,,,,,,) = nft.modelAsset(cursor);
+            if (parentModelId == bytes32(0)) break;
+            cursor = nft.tokenIdByModelId(parentModelId);
+            hops++;
+        }
+        assertEq(cursor, baseTok);
+        assertEq(hops, 2);
+
+        // ── Each token carries a verified training attestation. ──
+        attVerifier.setAcceptAll(true);
+        hook.registerAndVerifyAttestation(baseTok, BASE_ID, BASE_ART, KIND_ZK_TEE, "att-base");
+        hook.registerAndVerifyAttestation(ftTok, FT_ID, FT_ART, KIND_ZK_TEE, "att-ft");
+        hook.registerAndVerifyAttestation(distillTok, DISTILL_ID, DISTILL_ART, KIND_ZK_TEE, "att-distill");
+
+        (bytes32 m, bytes32 a, , bytes32 kind, address v, uint64 ts) = hook.attestationsByTokenId(distillTok);
+        assertEq(m, DISTILL_ID);
+        assertEq(a, DISTILL_ART);
+        assertEq(kind, KIND_ZK_TEE);
+        assertEq(v, address(attVerifier));
+        assertGt(ts, 0);
+
+        // ── Creator stamps the attestation kind onto the token itself. ──
+        vm.prank(creator);
+        nft.setAttestationKind(distillTok, KIND_ZK_TEE);
+
+        // ── ZK proof anchors the leaf to its on-chain artifact hash. ──
+        uint256[] memory proof = new uint256[](1);
+        proof[0] = 7;
+        uint256[] memory inputs = new uint256[](1);
+        inputs[0] = uint256(DISTILL_ART);
+        stub.submitProof(distillTok, DISTILL_ART, proof, inputs, address(zkVerifier));
+
+        bytes32 proofHash = stub.getTokenProofHash(distillTok);
+        ERC721AIZkVerifierStub.VerificationRecord memory rec = stub.getVerificationRecord(proofHash);
+        assertEq(rec.tokenId, distillTok);
+        assertEq(rec.artifactHash, DISTILL_ART);
+        assertTrue(rec.passed);
+    }
+
+    function test_CannotMintDerivedBeforeParentExists() public {
+        // Referencing a modelId that has not been minted yet must revert.
+        vm.prank(creator);
+        vm.expectRevert(ERC721AI.BaseModelNotFound.selector);
+        nft.mintModel(holder, FT_ID, FT_ART, BASE_ID, "", "", "", "", 0);
+    }
+
+    function test_AttestationSurvivesTokenTransfer() public {
+        uint256 tok = _mint(BASE_ID, BASE_ART, bytes32(0));
+        attVerifier.setAcceptAll(true);
+        hook.registerAndVerifyAttestation(tok, BASE_ID, BASE_ART, KIND_ZK_TEE, "att");
+
+        // Holder sells the token to a new owner.
+        address buyer = makeAddr("buyer");
+        vm.prank(holder);
+        nft.transferFrom(holder, buyer, tok);
+        assertEq(nft.ownerOf(tok), buyer);
+
+        // Attestation provenance is unaffected by ownership change.
+        (bytes32 m,,,,,uint64 ts) = hook.attestationsByTokenId(tok);
+        assertEq(m, BASE_ID);
+        assertGt(ts, 0);
+
+        // Royalty still routes to the original creator after the sale.
+        (address receiver,) = nft.royaltyInfo(tok, 1 ether);
+        assertEq(receiver, creator);
+    }
+
+    function test_AttestationKindOnTokenMatchesHookKind() public {
+        uint256 tok = _mint(BASE_ID, BASE_ART, bytes32(0));
+        attVerifier.setAcceptAll(true);
+        hook.registerAndVerifyAttestation(tok, BASE_ID, BASE_ART, KIND_ZK_TEE, "att");
+
+        // The hook recorded KIND_ZK_TEE for this token.
+        (,,, bytes32 hookKind,,) = hook.attestationsByTokenId(tok);
+        assertEq(hookKind, KIND_ZK_TEE);
+
+        // The creator stamps the SAME kind onto the token; modelAsset does not
+        // expose attestationKind, so we assert the on-chain write via its event.
+        vm.expectEmit(true, false, false, true);
+        emit ERC721AI.AttestationKindUpdated(tok, hookKind);
+        vm.prank(creator);
+        nft.setAttestationKind(tok, hookKind);
+    }
+
+    function test_RevertWhenNonCreatorStampsAttestationKindInLineage() public {
+        uint256 tok = _mint(BASE_ID, BASE_ART, bytes32(0));
+        // holder owns the token but is not the creator.
+        vm.prank(holder);
+        vm.expectRevert(ERC721AI.NotOwnerOrApproved.selector);
+        nft.setAttestationKind(tok, KIND_ZK_TEE);
+    }
+}

--- a/test/mocks/MockUSDC.sol
+++ b/test/mocks/MockUSDC.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @dev Minimal 6-decimal USDC-like token for metering tests. Anyone may mint.
+contract MockUSDC is ERC20 {
+    constructor() ERC20("Mock USDC", "USDC") {}
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/test/mocks/MockZkVerifier.sol
+++ b/test/mocks/MockZkVerifier.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IZkVerifier} from "../../contracts/extensions/ERC721AIZkVerifierStub.sol";
+
+/// @dev Toggleable ZK verifier used to drive ERC721AIZkVerifierStub down both
+///      the passing and failing branches deterministically.
+contract MockZkVerifier is IZkVerifier {
+    bool public result = true;
+
+    function setResult(bool value) external {
+        result = value;
+    }
+
+    function verifyProof(uint256[] calldata, uint256[] calldata) external view override returns (bool) {
+        return result;
+    }
+}

--- a/test/mocks/RevertingUSDC.sol
+++ b/test/mocks/RevertingUSDC.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @dev USDC-like token whose transfers can be toggled to fail. Used to prove
+///      metering propagates a failed settlement (SafeERC20 revert) rather than
+///      silently crediting revenue.
+contract RevertingUSDC is ERC20 {
+    bool public failTransfers;
+
+    constructor() ERC20("Reverting USDC", "rUSDC") {}
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function setFailTransfers(bool value) external {
+        failTransfers = value;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        if (failTransfers) return false; // SafeERC20 must treat this as a failure
+        return super.transferFrom(from, to, amount);
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        if (failTransfers) return false;
+        return super.transfer(to, amount);
+    }
+}


### PR DESCRIPTION
## Summary

Strengthens the Foundry suite on the weakest-tested seams of the ERC-721 AI contracts: the attestation/ZK verification path and the x402 per-inference metering. Two production contracts (`ERC721AIx402Metering`, `ERC721AIZkVerifierStub`) previously had **zero** tests; this adds focused unit, integration, and fuzz coverage and takes the suite from **34 → 82 passing tests**. No production code changed — tests and test-only mocks only.

## What was added

**`test/ERC721AIx402Metering.t.sol` (35 tests, was untested)**
- Registration: dedupe revert (same and different caller), zero-price revert, owner/price/active stored.
- Endpoint/price mutation: owner-only price update + event, zero-price update revert, non-owner revert, set-price-on-unregistered revert.
- Active toggle: deactivate/reactivate, non-owner revert.
- Pay / settle (single + batch): exact fee-split accounting, revenue accumulation, contract custody, `fee=0` and max-fee paths, inactive/unregistered-model reverts, insufficient-balance/no-approval reverts, batch-of-zero, single+batch consistency.
- Withdraw: transfer + balance reset + event, fee-recipient withdrawal, zero-balance no-op, double-withdraw drains once.
- SafeERC20 settlement-failure propagation via a reverting token (no revenue credited, no inference counted on revert).
- Admin protocol-fee gating: admin-only update + event, fee-too-high revert, fee change affects subsequent payments.
- Fuzz: fee-split value-conservation invariant (`owner + fee == price`, `fee <= ceiling`) and batch accounting invariant.

**`test/ERC721AIZkVerifierStub.t.sol` (8 tests, was untested)**
- Passing and failing proof records (failing proofs still recorded for audit).
- Record binds to the **on-chain** artifact hash, ignoring a caller-supplied bogus hash (provenance anchor).
- Token-not-found revert, proofHash mutation determinism, permissionless submission, unset-hash is zero.

**`test/ProvenanceLineage.t.sol` (5 integration tests)**
- Three-hop `base → fine-tune → distill` lineage; parent walk via `tokenIdByModelId`.
- Per-token training attestation through the hook + creator-only attestation-kind stamping.
- ZK proof anchoring the leaf to its on-chain artifact hash.
- Attestation + ERC-2981 royalty survive an ownership transfer.
- `BaseModelNotFound` when minting a derived model before its parent exists; non-creator stamping reverts.

**Test mocks** (`test/mocks/`): `MockUSDC` (6-decimal ERC20), `RevertingUSDC` (toggleable transfer failure for SafeERC20 path), `MockZkVerifier` (toggleable proof result).

## Verification

```
forge build   # Compiler run successful (clean build, 43 files), exit 0
forge test    # 82 passed; 0 failed; 0 skipped (5 suites)
```

Per-suite: ERC721AI 19, ERC721AIAttestationHook 15, ERC721AIx402Metering 35, ERC721AIZkVerifierStub 8, ProvenanceLineage 5.

Dependencies (`forge-std`, `openzeppelin-contracts`) are installed by CI via `forge install --no-git`, matching the existing workflow; no lib/ vendoring is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)